### PR TITLE
feat: Reverse Proxy 생성

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:latest
+
+COPY nginx.conf /etc/nginx/nginx.conf
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,71 @@
+user ubuntu;
+worker_processes auto;
+worker_rlimit_nofile 100000;
+
+error_log /var/log/nginx/error.log warn;
+
+events {
+    worker_connections 2048;
+    use epoll;
+    multi_accept on;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log /var/log/nginx/access.log main;
+
+    sendfile on;
+    server_tokens off;
+    client_max_body_size 200M;
+
+    keepalive_requests 1024;
+    keepalive_timeout 65;
+    reset_timedout_connection on;
+    send_timeout 10;
+    client_header_timeout 60s;
+    client_body_timeout 60s; 
+
+    tcp_nopush on;
+    tcp_nodelay on;
+
+    charset UTF-8;
+    gzip on;
+    gzip_min_length 1024;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_disable "msie6";
+
+    server {
+        listen 80;
+
+        server_name pofo.kr;
+
+        location / {
+            proxy_pass http://nextjs:3000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /api/ {
+            rewrite ^/api/(.*)$ /$1 break;
+            proxy_pass http://spring:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_buffering on;
+        }
+
+        # error_page 404 /404.html;
+        # location = /404.html {
+        #     root /usr/share/nginx/html;
+        # }
+    }
+}


### PR DESCRIPTION
## Overview
nginx reverse proxy를 생성했습니다.

### Related Issue
Issue Number : #38 

## Task Details

Nginx Reverse Proxy와 Dockerfile 추가했습니다. 주목해야될 부분이 몇가지가 있습니다. (관련 자료는 슬랙에 다 보내놨습니다.)

```
location /api/ {
            rewrite ^/api/(.*)$ /$1 break;
           ....
}
```

우선 subdomain으로 Routing이 되는 것이 아닌, /api prefix request는 rewrite되어 요청이 보내집니다. 추후, subdomain으로 변경될 수 있습니다.

```
client_max_body_size 200M;
```

두번째, 최대 파일 크기는 200MB입니다. 즉, 200MB를 초과하는 파일은 Nginx단에서 차단당합니다. 이 값은 추후 테스트를 통해 조정할 필요가 있습니다.

```
worker_processes auto;
worker_rlimit_nofile 100000;

events {
    worker_connections 2048;
}
```

세번째, worker에 관련된 설정입니다.worker process 개수는 cpu core 개수에 따라 자동으로 설정되는게 좋아 auto로 했습니다. 또한, worker_rlimit_nofile는 worker_connections의 두 배 이상이어야 합니다. 하지만, worker_rlimit_nofile 값이 너무 낮게 설정되면 고부하 환경에서 문제가 발생할 수 있습니다. Nginx는 워커 프로세스가 연결마다 파일 디스크립터를 사용하는 구조로 동작하기 때문에, 설정된 값이 실제 워크로드를 처리하기에 충분하지 않으면 병목이 발생할 가능성이 큽니다. 그래서 일단 넉넉하게 해놨지만 이게 서버마다 처리할 수 있는 fd가 다르기 때문에 테스트를 통해 값 조정이 필요합니다. worker_connection도 default는 1024인데 2048로 늘렸습니다. 제가 외국민에서 전에 해보니깐 1024로 하기에는 부하테스트가 어렵습니다. 문제가 많아서 2048로 했습니다. connection 개수도 적절히 조절해야 됩니다.

```
use epoll;
multi_accept on;
```

![image](https://github.com/user-attachments/assets/767d5bd2-3506-46ec-ab84-01d99a711fd7)

multi-accept를 통해서 워커 프로세스가 한 번에 여러 클라이언트 연결을 수락하도록 설정해서 성능을 좀 더 개선할 수 있도록 구성했습니다. 무엇보다 중요한 것은 epoll입니다. 아시다 싶이, Nginx는 Non-blocking I/O 싱글 스레드 방식으로 작동합니다. 이 말은 즉슨, Nginx는 연결된 Socket에 읽을 데이터가 있는지 (어느 것이 읽거나 쓸 준비가 되었는지를 식별) 지속적으로 확인하는 과정에서 리소스가 낭비됩니다. 그래서 아마 linux에서 소캣 관리하는 방식 크게 3가지 select, poll, epoll에 대해서 아실거라 생각됩니다. use epoll을 통해 소캣 관리 방식을 변경해서 유휴 연결 판단하는 방식이 epoll로 작동되로고 했습니다.

```
keepalive_requests 1024;
keepalive_timeout 65;
reset_timedout_connection on;
send_timeout 10;
```

http에서 keepalive의 개념은 아실거라 생각됩니다. 이게 없으면 매번 Spring Container와 TCP Handshaking 과정이 들어가서 불필요한 리소스 낭비가 발생합니다.그래서 이 부분을 설정해줬습니다. 이 값도 테스트를 통해 튜닝이 필요합니다. timeout 값도 튜닝이 필요하고요. 일단 제가 생각하기에 적합한 값을 넣어두긴 했습니다.

어쨋든!! 진짜 구체적인 수치는 사실 그 인스턴스 리소스 성능에 따라 달라지기 때문에 테스트를 통해 조정이 필요하지만, 일반적인 프리티어 성능에서의 값의 적절성과 추가한 설정의 적절성에 대해서 리뷰해주시기 바랍니다.

## Review Requirements

Nginx 설정과 그 값의 적절성에 대해서 리뷰해주시기 바랍니다.
Nginx 설정이 길어질수록 복잡성 때문에 일반적으로 파일을 분리하고 include 하나, 지금은 할 단게가 아니라고 판단해서 (server 블럭 및 location 블럭이 길어질 경우 보통 분리함) 분리 안했습니다. 우선 Dev 서버 라우팅이 우선이기 때문에