### PR TITLE
feat: domain property 추가 및 cors 설정

### DIFF
--- a/pofo-api/Dockerfile
+++ b/pofo-api/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:17
 ARG JAR_FILE=./build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 
-ARG PROFILE=prod
+ARG PROFILE=dev
 ENV PROFILE=${PROFILE}
 
 ENTRYPOINT ["java", "-Dspring.profiles.active=${PROFILE}", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]

--- a/pofo-api/src/main/kotlin/org/pofo/api/security/SecurityConfig.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/security/SecurityConfig.kt
@@ -6,6 +6,7 @@ import org.pofo.api.security.jwt.JwtAuthenticationFilter
 import org.pofo.api.security.oauth2.OAuth2AuthenticationFailureHandler
 import org.pofo.api.security.oauth2.OAuth2AuthenticationService
 import org.pofo.api.security.oauth2.OAuth2AuthenticationSuccessHandler
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
@@ -27,6 +28,9 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 @EnableWebSecurity
 @EnableMethodSecurity
 class SecurityConfig {
+    @Value("\${pofo.domain}")
+    private lateinit var domain: String
+
     @Bean
     fun filterChain(
         http: HttpSecurity,
@@ -76,7 +80,7 @@ class SecurityConfig {
 
     fun corsConfigurationSource(): CorsConfigurationSource {
         val corsConfiguration = CorsConfiguration()
-        corsConfiguration.allowedOrigins = listOf("*")
+        corsConfiguration.allowedOrigins = listOf(domain)
         corsConfiguration.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
         corsConfiguration.allowedHeaders = listOf("*")
         corsConfiguration.allowCredentials = true

--- a/pofo-api/src/main/kotlin/org/pofo/api/security/oauth2/OAuth2AuthenticationFailureHandler.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/security/oauth2/OAuth2AuthenticationFailureHandler.kt
@@ -9,14 +9,14 @@ import org.springframework.stereotype.Component
 
 @Component
 class OAuth2AuthenticationFailureHandler : SimpleUrlAuthenticationFailureHandler() {
-    @Value("\${oauth2.target-url}")
-    private lateinit var redirectUrl: String
+    @Value("\${pofo.domain}")
+    private lateinit var domain: String
 
     override fun onAuthenticationFailure(
         request: HttpServletRequest,
         response: HttpServletResponse,
         exception: AuthenticationException,
     ) {
-        redirectStrategy.sendRedirect(request, response, "$redirectUrl?error=1")
+        redirectStrategy.sendRedirect(request, response, "$domain/login/callback?error=1")
     }
 }

--- a/pofo-api/src/main/kotlin/org/pofo/api/security/oauth2/OAuth2AuthenticationSuccessHandler.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/security/oauth2/OAuth2AuthenticationSuccessHandler.kt
@@ -20,8 +20,8 @@ class OAuth2AuthenticationSuccessHandler(
     private val refreshTokenRepository: RefreshTokenRepository,
     private val cookieUtil: CookieUtil,
 ) : SimpleUrlAuthenticationSuccessHandler() {
-    @Value("\${oauth2.target-url}")
-    private lateinit var redirectUrl: String
+    @Value("\${pofo.domain}")
+    private lateinit var domain: String
 
     override fun onAuthenticationSuccess(
         request: HttpServletRequest,
@@ -43,6 +43,6 @@ class OAuth2AuthenticationSuccessHandler(
                 JwtService.REFRESH_TOKEN_EXPIRATION,
             )
         response.setHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
-        redirectStrategy.sendRedirect(request, response, "$redirectUrl?access_token=$accessToken")
+        redirectStrategy.sendRedirect(request, response, "$domain/login/callback?access_token=$accessToken")
     }
 }

--- a/pofo-api/src/main/resources/application-oauth2.yml
+++ b/pofo-api/src/main/resources/application-oauth2.yml
@@ -1,34 +1,9 @@
-oauth2:
-  target-url: ${OAUTH2_TARGET_URL:http://localhost:3000/oauth2/callback}
-
----
-
 spring:
-  config:
-    activate:
-      on-profile: local
-
   security:
     oauth2:
       client:
         registration:
           github:
-            client-id: invalid_client_id
-            client-secret: invalid_secret
-            redirect-uri: invalid_redirect_uri
-
----
-
-spring:
-  config:
-    activate:
-      on-profile: dev, prod
-
-  security:
-    oauth2:
-      client:
-        registration:
-          github:
-            client-id: ${OAUTH2_GITHUB_CLIENT_ID}
-            client-secret: ${OAUTH2_GITHUB_CLIENT_SECRET}
-            redirect-uri: ${OAUTH2_GITHUB_REDIRECT_URI}
+            client-id: ${OAUTH2_GITHUB_CLIENT_ID:invalid_client_id}
+            client-secret: ${OAUTH2_GITHUB_CLIENT_SECRET:invalid_client_secret}
+            redirect-uri: ${OAUTH2_GITHUB_REDIRECT_URI:invalid_redirect_uri}

--- a/pofo-api/src/main/resources/application.yml
+++ b/pofo-api/src/main/resources/application.yml
@@ -19,6 +19,9 @@ spring:
 jwt:
   secretKey: ${JWT_SECRET_KEY:not_secured_secretnot_secured_secretnot_secured_secretnot_secured_secretnot_secured_secret}
 
+pofo:
+  domain: ${POFO_DOMAIN:http://localhost:3000}
+
 ---
 
 spring:


### PR DESCRIPTION
## Overview

cors 설정을 위해 domain property를 추가했습니다.

### Related Issue
Issue Number : resolves #54 

## Task Details

도메인에 대한 값을 동적으로 해서 cors 객체를 설정하는게
프로파일 별로 Configuration 빈을 따로 설정하는 것보다 간단하다고 생각했습니다.

![image](https://github.com/user-attachments/assets/b274fc0a-3a69-4e2f-bd28-6591eb636c89)

따라서 동적으로 값을 추가했고 이를 allowedOrigins에 넣었습니다.

```java
@Value("\${pofo.domain}")
private lateinit var domain: String

fun corsConfigurationSource(): CorsConfigurationSource {
    val corsConfiguration = CorsConfiguration()
    corsConfiguration.allowedOrigins = listOf(domain)
    corsConfiguration.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
    corsConfiguration.allowedHeaders = listOf("*")
    corsConfiguration.allowCredentials = true
    val source = UrlBasedCorsConfigurationSource()
    source.registerCorsConfiguration("/**", corsConfiguration)
    return source
}
```

추가적으로 이 값은 OAuth2Handler에도 사용됩니다. 중복인거같아서 이걸로 사용했습니다.
```java
redirectStrategy.sendRedirect(request, response, "$domain/login/callback?access_token=$accessToken")
```

## Review Requirements
