### PR TITLE
fix: RefreshToken 도메인 설정 및 re-issue 권한 수정

### DIFF
--- a/pofo-api/src/main/kotlin/org/pofo/api/common/util/CookieUtil.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/common/util/CookieUtil.kt
@@ -26,28 +26,44 @@ class CookieUtil {
     /**
      * cookieName에 해당하는 쿠키를 생성합니다.
      *
-     * @param cookieName String 생성할 쿠키의 이름
-     * @param value      String 생성할 쿠키의 값
-     * @param maxAge     Long   생성할 쿠키의 만료 시간
+     * @param cookieName    String  생성할 쿠키의 이름
+     * @param value         String  생성할 쿠키의 값
+     * @param maxAge        Long    생성할 쿠키의 만료 시간
+     * @param domain        String? 생성할 쿠키의 타겟 도메인
+     * @param path          String  생성할 쿠키의 타겟 경로
      * @return ResponseCookie   생성된 쿠키
      */
     fun createCookie(
         cookieName: String,
         value: String,
         maxAge: Long,
-    ): ResponseCookie =
-        ResponseCookie
-            .from(cookieName, value)
-            .path("/")
-            .httpOnly(true)
-            .secure(true)
-            .maxAge(maxAge)
-            .build()
+        domain: String? = null,
+        path: String = "/",
+    ): ResponseCookie {
+        val cookieBuilder =
+            ResponseCookie
+                .from(cookieName, value)
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .maxAge(maxAge)
+                .path(path)
+
+        if (domain != null) {
+            cookieBuilder.domain(domain)
+        }
+
+        return cookieBuilder.build()
+    }
 
     /**
      * cookieName에 해당하는 쿠키를 제거합니다.
      *
      * @return ResponseCookie   쿠키의 maxAge가 0인 쿠키
      */
-    fun createDeletingCookie(cookieName: String): ResponseCookie = createCookie(cookieName, "", 0)
+    fun createDeletingCookie(
+        cookieName: String,
+        domain: String? = null,
+        path: String = "/",
+    ): ResponseCookie = createCookie(cookieName = cookieName, value = "", maxAge = 0, domain = domain, path = path)
 }

--- a/pofo-api/src/main/kotlin/org/pofo/api/security/SecurityConfig.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/security/SecurityConfig.kt
@@ -50,11 +50,8 @@ class SecurityConfig {
             httpBasic { disable() }
             authorizeHttpRequests {
                 authorize(AntPathRequestMatcher("/h2-console/**"), permitAll)
-                authorize(AntPathRequestMatcher("/graphql"), permitAll)
-                authorize("/graphiql", permitAll)
-                authorize(HttpMethod.POST, "/user", permitAll)
-                authorize(HttpMethod.POST, "/user/login", permitAll)
-                authorize(HttpMethod.POST, "/user/logout", permitAll)
+                listOf("/graphql", "/graphiql").forEach { authorize(it, permitAll) }
+                listOf("/user", "/user/login", "/user/re-issue").forEach { authorize(HttpMethod.POST, it, permitAll) }
                 authorize("/tech-stack/**", permitAll)
                 authorize(anyRequest, authenticated)
             }

--- a/pofo-api/src/test/kotlin/org/pofo/api/controller/UserControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/controller/UserControllerTest.kt
@@ -98,6 +98,11 @@ internal class UserControllerTest
                             status { isOk() }
                             cookie {
                                 exists(UserController.REFRESH_COOKIE_NAME)
+                                domain(UserController.REFRESH_COOKIE_NAME, "localhost")
+                                maxAge(
+                                    UserController.REFRESH_COOKIE_NAME,
+                                    (JwtService.REFRESH_TOKEN_EXPIRATION / 1000).toInt(),
+                                )
                             }
                             jsonPath("$.data.accessToken") { exists() }
                         }
@@ -140,6 +145,7 @@ internal class UserControllerTest
                             status { isOk() }
                             cookie {
                                 exists(UserController.REFRESH_COOKIE_NAME)
+                                domain(UserController.REFRESH_COOKIE_NAME, "localhost")
                                 maxAge(UserController.REFRESH_COOKIE_NAME, 0)
                                 value(UserController.REFRESH_COOKIE_NAME, "")
                             }


### PR DESCRIPTION
## Overview

RefreshToken의 도메인이 개발 서버의 IP로 설정되고 있어 설정된 도메인으로 수정했습니다.

### Related Issue
Issue Number : resolves #58 

## Task Details

추가적으로 re-issue가 AccessToken이 필요하다고 해서 permitAll 했습니다.

## Review Requirements
