### PR TITLE
fix: RefreshToken 쿠키의 만료 기간 수정

### DIFF
--- a/pofo-api/src/main/kotlin/org/pofo/api/controller/UserController.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/controller/UserController.kt
@@ -82,7 +82,7 @@ class UserController(
         val cookie =
             cookieUtil.createCookie(
                 cookieName = REFRESH_COOKIE_NAME,
-                maxAge = JwtService.REFRESH_TOKEN_EXPIRATION,
+                maxAge = JwtService.REFRESH_TOKEN_EXPIRATION / 1000,
                 value = tokenResponse.refreshToken,
             )
 


### PR DESCRIPTION
## Overview

RefreshToken의 쿠키 만료 기간이 ms 기준으로 되어있어 너무 긴 기간으로 설정되고 있었습니다.

### Related Issue
Issue Number : resolves #58 

## Task Details

RefreshToken 쿠키 만료 기간을 1000으로 나누어 집어 넣었습니다.
기간은 15일입니다.

## Screenshots (Optional)

## Test Scope & Checklist (Optional)

- [ ] Test Task 1
- [ ] Test Task 2

## Review Requirements
