### PR TITLE
feat: 4xx 상황의 에러 핸들링 추가

### DIFF
--- a/pofo-api/src/main/kotlin/org/pofo/api/common/exception/handler/ApiExceptionHandler.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/common/exception/handler/ApiExceptionHandler.kt
@@ -9,9 +9,12 @@ import org.pofo.common.exception.ErrorCode
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.core.AuthenticationException
+import org.springframework.web.HttpMediaTypeNotSupportedException
+import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.NoHandlerFoundException
 
 private val logger = KotlinLogging.logger {}
 
@@ -29,18 +32,16 @@ class ApiExceptionHandler {
      */
     @ExceptionHandler(AuthenticationException::class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    fun handleAuthenticationException(exception: AuthenticationException): ApiResponse<Nothing> {
-        return ApiResponse.failure(ErrorCode.UNAUTHORIZED)
-    }
+    fun handleAuthenticationException(exception: AuthenticationException): ApiResponse<Nothing> =
+        ApiResponse.failure(ErrorCode.UNAUTHORIZED)
 
     /**
      * 인가 오류를 검출합니다.
      */
     @ExceptionHandler(AccessDeniedException::class)
     @ResponseStatus(HttpStatus.FORBIDDEN)
-    fun handleAccessDeniedException(exception: AccessDeniedException): ApiResponse<Nothing> {
-        return ApiResponse.failure(ErrorCode.FORBIDDEN)
-    }
+    fun handleAccessDeniedException(exception: AccessDeniedException): ApiResponse<Nothing> =
+        ApiResponse.failure(ErrorCode.FORBIDDEN)
 
     /**
      * 서비스 로직의 오류를 검출합니다.
@@ -56,6 +57,31 @@ class ApiExceptionHandler {
         response.contentType = MediaType.APPLICATION_JSON_VALUE
         objectMapper.writeValue(response.writer, ApiResponse.failure(errorCode))
     }
+
+    /**
+     * 잘못된 URL 호출을 검출합니다.
+     */
+    @ExceptionHandler(NoHandlerFoundException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    fun handleNoHandlerFoundException(exception: NoHandlerFoundException): ApiResponse<Nothing> =
+        ApiResponse.failure(ErrorCode.NOT_FOUND)
+
+    /**
+     * 지원하지 않는 Content-Type을 검출합니다.
+     */
+    @ExceptionHandler(HttpMediaTypeNotSupportedException::class)
+    @ResponseStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+    fun handleHttpMediaTypeNotSupportedException(exception: HttpMediaTypeNotSupportedException): ApiResponse<Nothing> =
+        ApiResponse.failure(ErrorCode.UNSUPPORTED_MEDIA_TYPE)
+
+    /**
+     * 허용되지 않은 Method 호출을 검출합니다.
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
+    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+    fun handleHttpRequestMethodNotSupportedException(
+        exception: HttpRequestMethodNotSupportedException,
+    ): ApiResponse<Nothing> = ApiResponse.failure(ErrorCode.METHOD_NOT_ALLOWED)
 
     /**
      * 처리되지 않은 오류를 검출합니다.

--- a/pofo-common/src/main/kotlin/org/pofo/common/exception/ErrorCode.kt
+++ b/pofo-common/src/main/kotlin/org/pofo/common/exception/ErrorCode.kt
@@ -8,6 +8,9 @@ enum class ErrorCode(
     INTERNAL_SERVER_ERROR(500, "서버 오류", "COMMON-001"),
     UNAUTHORIZED(401, "인증 오류", "COMMON-002"),
     FORBIDDEN(403, "인가 오류", "COMMON-003"),
+    NOT_FOUND(404, "잘못된 URL 호출", "COMMON-004"),
+    METHOD_NOT_ALLOWED(405, "허용되지 않는 메소드", "COMMON-005"),
+    UNSUPPORTED_MEDIA_TYPE(415, "지원하지 않는 Content 형식", "COMMON-006"),
 
     // USER
     USER_NOT_FOUND(404, "유저를 찾을 수 없습니다.", "USER-001"),
@@ -15,5 +18,5 @@ enum class ErrorCode(
     USER_LOGIN_FAILED(401, "아이디 또는 비밀번호가 잘못되었습니다.", "USER-003"),
 
     // PROJECT
-    PROJECT_NOT_FOUND(404, "프로젝트를 찾을 수 없습니다.", "PROJ-004"),
+    PROJECT_NOT_FOUND(404, "프로젝트를 찾을 수 없습니다.", "PROJ-001"),
 }


### PR DESCRIPTION
## Overview

404, 405, 415 status에 대한 에러 처리를 추가했습니다.

### Related Issue
Issue Number : resolves #56 

## Task Details

```java
NOT_FOUND(404, "잘못된 URL 호출", "COMMON-004"),
METHOD_NOT_ALLOWED(405, "허용되지 않는 메소드", "COMMON-005"),
UNSUPPORTED_MEDIA_TYPE(415, "지원하지 않는 Content 형식", "COMMON-006"),
```

위 세개의 대한 핸들러 추가

## Review Requirements

인증되지 않은 요청에는 401 오류가 먼저 나오는데 이게 맞는지 물어보고 싶습니다. (보안적으론 유리하다고 판단합니다.)
