### PR TITLE
feat: Swagger API Docs 추가

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,8 +23,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.ACCESS_TOKEN }}
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/pofo-api/build.gradle.kts
+++ b/pofo-api/build.gradle.kts
@@ -28,4 +28,6 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.12.6")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
+
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
 }

--- a/pofo-api/src/main/kotlin/org/pofo/api/common/response/ApiResponse.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/common/response/ApiResponse.kt
@@ -2,13 +2,17 @@ package org.pofo.api.common.response
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
 import org.pofo.common.exception.ErrorCode
 
+@Schema(description = "API 응답 모델")
 class ApiResponse<T> {
+    @Schema(description = "요청 성공 여부", example = "true")
     @JsonProperty
     private val success: Boolean
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "에러 코드", example = "C001")
     val code: String?
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -27,12 +31,8 @@ class ApiResponse<T> {
     }
 
     companion object {
-        fun <T> success(data: T): ApiResponse<T> {
-            return ApiResponse(data)
-        }
+        fun <T> success(data: T): ApiResponse<T> = ApiResponse(data)
 
-        fun failure(errorCode: ErrorCode): ApiResponse<Nothing> {
-            return ApiResponse(errorCode)
-        }
+        fun failure(errorCode: ErrorCode): ApiResponse<Nothing> = ApiResponse(errorCode)
     }
 }

--- a/pofo-api/src/main/kotlin/org/pofo/api/config/SwaggerConfig.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/config/SwaggerConfig.kt
@@ -1,0 +1,84 @@
+package org.pofo.api.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.media.BooleanSchema
+import io.swagger.v3.oas.models.media.ObjectSchema
+import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.media.StringSchema
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springdoc.core.customizers.OperationCustomizer
+import org.springdoc.core.models.GroupedOpenApi
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+@Configuration
+@Profile("local", "dev")
+class SwaggerConfig {
+    private val token = "JWT"
+
+    @Bean
+    fun operationCustomizer(): OperationCustomizer =
+        OperationCustomizer { operation, _ ->
+            operation.responses?.let { responses ->
+                responses.forEach { (_, apiResponse) ->
+                    apiResponse.content?.forEach { (_, mediaType) ->
+                        mediaType.schema = wrapSchema(mediaType.schema)
+                    }
+                }
+            }
+            operation
+        }
+
+    private fun wrapSchema(originalSchema: Schema<*>?): Schema<*> {
+        val wrapperSchema = ObjectSchema()
+
+        wrapperSchema.addProperty("success", BooleanSchema().example(true))
+        wrapperSchema.addProperty("code", StringSchema().example("C001"))
+        wrapperSchema.addProperty("data", originalSchema)
+
+        return wrapperSchema
+    }
+
+    // API 그룹화 필요시 추후 진행.
+    // 지금은 API가 몇개 없어서 단일 그룹으로 헀는데 추후 그룹화 하는게 좋습니다.
+    @Bean
+    fun techStackApi(): GroupedOpenApi =
+        GroupedOpenApi
+            .builder()
+            .packagesToScan("org.pofo.api.docs", "org.pofo.api.controller")
+            .group("Tech Stack API")
+            .build()
+
+    @Bean
+    fun openAPI(): OpenAPI {
+        val securityRequirement = SecurityRequirement().addList(token)
+
+        return OpenAPI()
+            .info(apiInfo())
+            .addSecurityItem(securityRequirement)
+            .components(securitySchemes())
+    }
+
+    private fun securitySchemes(): Components {
+        val securitySchemeAccessToken =
+            SecurityScheme()
+                .name(token)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("Bearer")
+                .bearerFormat("JWT")
+                .`in`(SecurityScheme.In.HEADER)
+                .name("Authorization")
+
+        return Components().addSecuritySchemes(token, securitySchemeAccessToken)
+    }
+
+    private fun apiInfo(): Info =
+        Info()
+            .title("Pofo API Docs")
+            .description("Pofo 플랫폼 API 명세서")
+            .version("v1.0.0")
+}

--- a/pofo-api/src/main/kotlin/org/pofo/api/controller/AutocompleteController.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/controller/AutocompleteController.kt
@@ -1,44 +1,43 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
 package org.pofo.api.controller
 
 import org.pofo.api.common.response.ApiResponse
+import org.pofo.api.docs.AutocompleteApiDocs
 import org.pofo.api.service.OpenSearchService
+import org.pofo.common.response.Version
 import org.pofo.infra.elasticsearch.document.TechStackAutoComplete
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 
-@RequestMapping("/tech-stack")
 @RestController
+@RequestMapping("/tech-stack")
 class AutocompleteController(
     private val openSearchService: OpenSearchService,
-) {
-    @PostMapping("/")
-    fun insertTechStack(
+) : AutocompleteApiDocs {
+    @PostMapping(Version.V1 + "/")
+    override fun insertTechStack(
         @RequestBody techStack: TechStackAutoComplete,
     ): ApiResponse<String> {
         openSearchService.indexTechStack(techStack)
-        return ApiResponse.success("단일 테이터 삽입 성공")
+        return ApiResponse.success("단일 데이터 삽입 성공")
     }
 
-    @PostMapping("/upload-csv")
-    fun uploadCSV(
+    @PostMapping(Version.V1 + "/upload-csv")
+    override fun uploadCSV(
         @RequestParam("file") file: MultipartFile,
     ): ApiResponse<String> {
         openSearchService.bulkInsertFromCSV(file)
         return ApiResponse.success("CSV 데이터 삽입 성공")
     }
 
-    @GetMapping("/autocomplete")
-    fun autoComplete(
+    @GetMapping(Version.V1 + "/autocomplete")
+    override fun autoComplete(
         @RequestParam query: String,
     ): ApiResponse<List<String>> = ApiResponse.success(openSearchService.getSuggestions(query))
 
-    @GetMapping("/field")
-    fun searchSingleField(
+    @GetMapping(Version.V1 + "/field")
+    override fun searchSingleField(
         @RequestParam field: String,
         @RequestParam keyword: String,
     ): ApiResponse<List<TechStackAutoComplete>> =

--- a/pofo-api/src/main/kotlin/org/pofo/api/controller/AutocompleteController.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/controller/AutocompleteController.kt
@@ -11,11 +11,11 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 
 @RestController
-@RequestMapping("/tech-stack")
+@RequestMapping(Version.V1 + "/tech-stack")
 class AutocompleteController(
     private val openSearchService: OpenSearchService,
 ) : AutocompleteApiDocs {
-    @PostMapping(Version.V1 + "/")
+    @PostMapping("/")
     override fun insertTechStack(
         @RequestBody techStack: TechStackAutoComplete,
     ): ApiResponse<String> {
@@ -23,7 +23,7 @@ class AutocompleteController(
         return ApiResponse.success("단일 데이터 삽입 성공")
     }
 
-    @PostMapping(Version.V1 + "/upload-csv")
+    @PostMapping("/upload-csv")
     override fun uploadCSV(
         @RequestParam("file") file: MultipartFile,
     ): ApiResponse<String> {
@@ -31,7 +31,7 @@ class AutocompleteController(
         return ApiResponse.success("CSV 데이터 삽입 성공")
     }
 
-    @GetMapping(Version.V1 + "/autocomplete")
+    @GetMapping("/autocomplete")
     override fun autoComplete(
         @RequestParam query: String,
     ): ApiResponse<Map<String, List<String>>> {
@@ -41,7 +41,7 @@ class AutocompleteController(
     }
 
     @Deprecated(message = "제거될 예정인 API 입니다")
-    @GetMapping(Version.V1 + "/field")
+    @GetMapping("/field")
     override fun searchSingleField(
         @RequestParam field: String,
         @RequestParam keyword: String,

--- a/pofo-api/src/main/kotlin/org/pofo/api/controller/AutocompleteController.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/controller/AutocompleteController.kt
@@ -34,8 +34,13 @@ class AutocompleteController(
     @GetMapping(Version.V1 + "/autocomplete")
     override fun autoComplete(
         @RequestParam query: String,
-    ): ApiResponse<List<String>> = ApiResponse.success(openSearchService.getSuggestions(query))
+    ): ApiResponse<Map<String, List<String>>> {
+        val suggestions = openSearchService.getSuggestions(query)
+        val responseData = mapOf("autocomplete" to suggestions)
+        return ApiResponse.success(responseData)
+    }
 
+    @Deprecated(message = "제거될 예정인 API 입니다")
     @GetMapping(Version.V1 + "/field")
     override fun searchSingleField(
         @RequestParam field: String,

--- a/pofo-api/src/main/kotlin/org/pofo/api/controller/ImageController.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/controller/ImageController.kt
@@ -8,9 +8,9 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/image")
+@RequestMapping(Version.V1 + "/image")
 class ImageController : ImageApiDocs {
-    @PostMapping(Version.V1 + "")
+    @PostMapping("")
     override fun uploadImage(): ApiResponse<Map<String, String>> {
         // TODO: Image Upload 로직 작성
         val tmp = "tmp"

--- a/pofo-api/src/main/kotlin/org/pofo/api/controller/ImageController.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/controller/ImageController.kt
@@ -1,0 +1,20 @@
+package org.pofo.api.controller
+
+import org.pofo.api.common.response.ApiResponse
+import org.pofo.api.docs.ImageApiDocs
+import org.pofo.common.response.Version
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/image")
+class ImageController : ImageApiDocs {
+    @PostMapping(Version.V1 + "")
+    override fun uploadImage(): ApiResponse<Map<String, String>> {
+        // TODO: Image Upload 로직 작성
+        val tmp = "tmp"
+        val responseData = mapOf("url" to tmp)
+        return ApiResponse.success(responseData)
+    }
+}

--- a/pofo-api/src/main/kotlin/org/pofo/api/controller/UserController.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/controller/UserController.kt
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping(Version.V1 + "/user")
+@RequestMapping("/user")
 class UserController(
     private val userService: UserService,
     private val cookieUtil: CookieUtil,

--- a/pofo-api/src/main/kotlin/org/pofo/api/controller/UserController.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/controller/UserController.kt
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/user")
+@RequestMapping(Version.V1 + "/user")
 class UserController(
     private val userService: UserService,
     private val cookieUtil: CookieUtil,
@@ -33,7 +33,7 @@ class UserController(
         const val REFRESH_COOKIE_NAME = "POFO_RTN"
     }
 
-    @PostMapping(Version.V1 + "")
+    @PostMapping("")
     override fun register(
         @RequestBody registerRequest: RegisterRequest,
     ): ApiResponse<User> {
@@ -41,7 +41,7 @@ class UserController(
         return ApiResponse.success(user)
     }
 
-    @GetMapping(Version.V1 + "/me")
+    @GetMapping("/me")
     override fun getMe(
         @AuthenticationPrincipal principalDetails: PrincipalDetails,
     ): ApiResponse<User> {
@@ -49,7 +49,7 @@ class UserController(
         return ApiResponse.success(user)
     }
 
-    @PostMapping(Version.V1 + "/login")
+    @PostMapping("/login")
     override fun login(
         response: HttpServletResponse,
         @RequestBody loginRequest: LoginRequest,
@@ -60,7 +60,7 @@ class UserController(
         return ApiResponse.success(tokenResponse)
     }
 
-    @PostMapping(Version.V1 + "/re-issue")
+    @PostMapping("/re-issue")
     override fun reIssue(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -91,7 +91,7 @@ class UserController(
         response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString())
     }
 
-    @PostMapping(Version.V1 + "/logout")
+    @PostMapping("/logout")
     override fun logout(
         request: HttpServletRequest,
         response: HttpServletResponse,

--- a/pofo-api/src/main/kotlin/org/pofo/api/controller/UserController.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/controller/UserController.kt
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.pofo.api.common.response.ApiResponse
 import org.pofo.api.common.util.CookieUtil
+import org.pofo.api.docs.UserApiDocs
 import org.pofo.api.dto.LoginRequest
 import org.pofo.api.dto.RegisterRequest
 import org.pofo.api.dto.TokenResponse
@@ -11,6 +12,7 @@ import org.pofo.api.security.PrincipalDetails
 import org.pofo.api.security.jwt.JwtService
 import org.pofo.api.service.UserService
 import org.pofo.common.exception.ErrorCode
+import org.pofo.common.response.Version
 import org.pofo.domain.rds.domain.user.User
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -22,33 +24,33 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/user")
+@RequestMapping(Version.V1 + "/user")
 class UserController(
     private val userService: UserService,
     private val cookieUtil: CookieUtil,
-) {
+) : UserApiDocs {
     companion object {
         const val REFRESH_COOKIE_NAME = "POFO_RTN"
     }
 
-    @PostMapping("")
-    fun register(
+    @PostMapping(Version.V1 + "")
+    override fun register(
         @RequestBody registerRequest: RegisterRequest,
     ): ApiResponse<User> {
         val user = userService.createUser(registerRequest)
         return ApiResponse.success(user)
     }
 
-    @GetMapping("/me")
-    fun getMe(
+    @GetMapping(Version.V1 + "/me")
+    override fun getMe(
         @AuthenticationPrincipal principalDetails: PrincipalDetails,
     ): ApiResponse<User> {
         val user = userService.getUserById(principalDetails.jwtTokenData.userId)
         return ApiResponse.success(user)
     }
 
-    @PostMapping("/login")
-    fun login(
+    @PostMapping(Version.V1 + "/login")
+    override fun login(
         response: HttpServletResponse,
         @RequestBody loginRequest: LoginRequest,
     ): ApiResponse<TokenResponse> {
@@ -58,8 +60,8 @@ class UserController(
         return ApiResponse.success(tokenResponse)
     }
 
-    @PostMapping("/re-issue")
-    fun reIssue(
+    @PostMapping(Version.V1 + "/re-issue")
+    override fun reIssue(
         request: HttpServletRequest,
         response: HttpServletResponse,
     ): ApiResponse<*> {
@@ -89,8 +91,8 @@ class UserController(
         response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString())
     }
 
-    @PostMapping("/logout")
-    fun logout(
+    @PostMapping(Version.V1 + "/logout")
+    override fun logout(
         request: HttpServletRequest,
         response: HttpServletResponse,
         @AuthenticationPrincipal principalDetails: PrincipalDetails,

--- a/pofo-api/src/main/kotlin/org/pofo/api/docs/AutocompleteApiDocs.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/docs/AutocompleteApiDocs.kt
@@ -1,0 +1,4 @@
+package org.pofo.api.docs
+
+class AutocompleteApiDocs {
+}

--- a/pofo-api/src/main/kotlin/org/pofo/api/docs/AutocompleteApiDocs.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/docs/AutocompleteApiDocs.kt
@@ -1,4 +1,46 @@
 package org.pofo.api.docs
 
-class AutocompleteApiDocs {
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.Parameters
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.pofo.api.common.response.ApiResponse
+import org.pofo.infra.elasticsearch.document.TechStackAutoComplete
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.multipart.MultipartFile
+
+@Tag(name = "[Tech Stack API]", description = "기술 스택 관련 API")
+interface AutocompleteApiDocs {
+    @Operation(summary = "단일 기술 스택 삽입", description = "단일 기술 스택 데이터를 OpenSearch에 삽입합니다.")
+    fun insertTechStack(
+        @RequestBody techStack: TechStackAutoComplete,
+    ): ApiResponse<String>
+
+    @Operation(summary = "CSV 파일 업로드", description = "CSV 파일의 기술 스택 데이터를 OpenSearch에 대량 삽입합니다.")
+    @Parameters(
+        Parameter(name = "file", description = "업로드할 CSV 파일", required = true, `in` = ParameterIn.QUERY),
+    )
+    fun uploadCSV(
+        @RequestParam("file") file: MultipartFile,
+    ): ApiResponse<String>
+
+    @Operation(summary = "자동완성 검색", description = "사용자가 입력한 키워드에 기반하여 자동완성 제안을 제공합니다.")
+    @Parameters(
+        Parameter(name = "query", description = "자동완성 검색어", required = true, `in` = ParameterIn.QUERY),
+    )
+    fun autoComplete(
+        @RequestParam("query") query: String,
+    ): ApiResponse<List<String>>
+
+    @Operation(summary = "단일 필드 검색", description = "특정 필드와 키워드로 기술 스택 데이터를 검색합니다.")
+    @Parameters(
+        Parameter(name = "field", description = "검색할 필드명", required = true, `in` = ParameterIn.QUERY),
+        Parameter(name = "keyword", description = "검색 키워드", required = true, `in` = ParameterIn.QUERY),
+    )
+    fun searchSingleField(
+        @RequestParam("field") field: String,
+        @RequestParam("keyword") keyword: String,
+    ): ApiResponse<List<TechStackAutoComplete>>
 }

--- a/pofo-api/src/main/kotlin/org/pofo/api/docs/AutocompleteApiDocs.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/docs/AutocompleteApiDocs.kt
@@ -4,21 +4,73 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.Parameters
 import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.pofo.api.common.response.ApiResponse
 import org.pofo.infra.elasticsearch.document.TechStackAutoComplete
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.multipart.MultipartFile
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerResponse
 
 @Tag(name = "[Tech Stack API]", description = "기술 스택 관련 API")
 interface AutocompleteApiDocs {
     @Operation(summary = "단일 기술 스택 삽입", description = "단일 기술 스택 데이터를 OpenSearch에 삽입합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerResponse(
+                responseCode = "200",
+                description = "기술스택 삽입 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        examples = [
+                            ExampleObject(
+                                name = "단일 기술스택 삽입 성공",
+                                value = """
+                                    {
+                                      "success": true,
+                                      "data": "성공하셨습니다"
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
     fun insertTechStack(
         @RequestBody techStack: TechStackAutoComplete,
     ): ApiResponse<String>
 
-    @Operation(summary = "CSV 파일 업로드", description = "CSV 파일의 기술 스택 데이터를 OpenSearch에 대량 삽입합니다.")
+    @Operation(summary = "CSV 파일 업로드", description = "CSV 파일의 기술 스택 데이터를 Bulk로 OpenSearch에 대량 삽입합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerResponse(
+                responseCode = "200",
+                description = "Batch로 기술 스택 삽입 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        examples = [
+                            ExampleObject(
+                                name = "단일 기술스택 삽입 성공",
+                                value = """
+                                    {
+                                      "success": true,
+                                      "data": "성공하셨습니다"
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
     @Parameters(
         Parameter(name = "file", description = "업로드할 CSV 파일", required = true, `in` = ParameterIn.QUERY),
     )
@@ -27,14 +79,99 @@ interface AutocompleteApiDocs {
     ): ApiResponse<String>
 
     @Operation(summary = "자동완성 검색", description = "사용자가 입력한 키워드에 기반하여 자동완성 제안을 제공합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerResponse(
+                responseCode = "200",
+                description = "회원가입 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        examples = [
+                            ExampleObject(
+                                name = "자동완성 성공 - Spring 입력시",
+                                value = """
+                                    {
+                                      "success": true,
+                                      "data":
+                                        "autocompelte" : [
+                                           "Spring", "Spring Batch", "Spring Cloud Gateway"
+                                        ]
+                                    }
+                                """,
+                            ),
+                            ExampleObject(
+                                name = "자동완성 성공 - AWS 입력시",
+                                value = """
+                                    {
+                                      "success": true,
+                                      "data":
+                                        "autocompelte" : [
+                                            "AWS EC2", "AWS RDS", "AWS SQS", "AWS Snowball", "AWS Redshift"
+                                        ]
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
     @Parameters(
         Parameter(name = "query", description = "자동완성 검색어", required = true, `in` = ParameterIn.QUERY),
     )
     fun autoComplete(
         @RequestParam("query") query: String,
-    ): ApiResponse<List<String>>
+    ): ApiResponse<Map<String, List<String>>>
 
     @Operation(summary = "단일 필드 검색", description = "특정 필드와 키워드로 기술 스택 데이터를 검색합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerResponse(
+                responseCode = "200",
+                description = "회원가입 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        examples = [
+                            ExampleObject(
+                                name = "단일 기술 스택 검색",
+                                value = """
+                                    {
+                                      "success": true,
+                                      "data":  "data": [
+                                        {
+                                          "id": "string",
+                                          "suggest": {
+                                            "input": [
+                                              "string"
+                                            ],
+                                            "contexts": {
+                                              "additionalProp1": [
+                                                "string"
+                                              ],
+                                              "additionalProp2": [
+                                                "string"
+                                              ],
+                                              "additionalProp3": [
+                                                "string"
+                                              ]
+                                            },
+                                            "weight": 0
+                                          },
+                                          "name": "string"
+                                        }
+                                      ]
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
     @Parameters(
         Parameter(name = "field", description = "검색할 필드명", required = true, `in` = ParameterIn.QUERY),
         Parameter(name = "keyword", description = "검색 키워드", required = true, `in` = ParameterIn.QUERY),

--- a/pofo-api/src/main/kotlin/org/pofo/api/docs/ImageApiDocs.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/docs/ImageApiDocs.kt
@@ -1,0 +1,54 @@
+package org.pofo.api.docs
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.pofo.api.common.response.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerResponse
+
+@Tag(name = "[Image API]", description = "이미지 관련 API")
+interface ImageApiDocs {
+    @Operation(summary = "이미지 업로드", description = "이미지를 업로드 합니다. (개발중)")
+    @ApiResponses(
+        value = [
+            SwaggerResponse(
+                responseCode = "200",
+                description = "이미지 업로드 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        examples = [
+                            ExampleObject(
+                                name = "이미지 S3에 업로드 성공",
+                                value = """
+                                    {
+                                      "success": true,
+                                      "data": {
+                                        "id": 0,
+                                        "email": "string"
+                                      }
+                                    }
+                                """,
+                            ),
+                            ExampleObject(
+                                name = "검증 성공 - 기존에 등록한 소셜 계정 없음 (스웨거 문서 제작 예시로 임시로 중복해서 넣었습니다)",
+                                value = """
+                                    {
+                                      "success": true,
+                                      "data": {
+                                        "id": 0,
+                                        "email": "string"
+                                      }
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun uploadImage(): ApiResponse<Map<String, String>>
+}

--- a/pofo-api/src/main/kotlin/org/pofo/api/docs/UserApiDocs.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/docs/UserApiDocs.kt
@@ -143,6 +143,7 @@ interface UserApiDocs {
         @Parameter(hidden = true) response: HttpServletResponse,
     ): ApiResponse<*>
 
+    // TODO : 여기 예시좀 적어주세요. Unit 타입이 뭔지 모르겠어요.
     @Operation(summary = "로그아웃", description = "현재 로그인된 사용자를 로그아웃하고 리프레시 토큰 쿠키를 제거합니다.")
     @ApiResponses(
         value = [

--- a/pofo-api/src/main/kotlin/org/pofo/api/docs/UserApiDocs.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/docs/UserApiDocs.kt
@@ -1,4 +1,160 @@
 package org.pofo.api.docs
 
-class UserApiDocs {
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.pofo.api.common.response.ApiResponse
+import org.pofo.api.dto.LoginRequest
+import org.pofo.api.dto.RegisterRequest
+import org.pofo.api.dto.TokenResponse
+import org.pofo.api.security.PrincipalDetails
+import org.pofo.domain.rds.domain.user.User
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.RequestBody
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerResponse
+
+@Tag(name = "[User API]", description = "유저 관련 API")
+interface UserApiDocs {
+    @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerResponse(
+                responseCode = "200",
+                description = "회원가입 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        examples = [
+                            ExampleObject(
+                                name = "검증 성공 - 기존에 등록한 소셜 계정 없음",
+                                value = """
+                                    {
+                                      "success": true,
+                                      "data": {
+                                        "id": 0,
+                                        "email": "string"
+                                      }
+                                    }
+                                """,
+                            ),
+                            ExampleObject(
+                                name = "검증 성공 - 기존에 등록한 소셜 계정 없음 (스웨거 문서 제작 예시로 임시로 중복해서 넣었습니다)",
+                                value = """
+                                    {
+                                      "success": true,
+                                      "data": {
+                                        "id": 0,
+                                        "email": "string"
+                                      }
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun register(
+        @RequestBody registerRequest: RegisterRequest,
+    ): ApiResponse<User>
+
+    @Operation(summary = "내 정보 조회", description = "토큰을 활용하여 현재 로그인된 사용자의 정보를 조회합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerResponse(
+                responseCode = "200",
+                description = "정보 조회 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        examples = [
+                            ExampleObject(
+                                name = "정보 조회 성공",
+                                value = """
+                                    {
+                                      "success": true,
+                                      "data": {
+                                        "id": 0,
+                                        "email": "string"
+                                      }
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getMe(
+        @AuthenticationPrincipal principalDetails: PrincipalDetails,
+    ): ApiResponse<User>
+
+    @Operation(summary = "로그인", description = "사용자 로그인 처리 및 토큰 발급합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerResponse(
+                responseCode = "200",
+                description = "로그인 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        examples = [
+                            ExampleObject(
+                                name = "로그인 성공",
+                                value = """
+                                    {
+                                      "success": true,
+                                      "data": {
+                                        "accessToken": "string"
+                                      }
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun login(
+        @Parameter(hidden = true) response: HttpServletResponse,
+        @RequestBody loginRequest: LoginRequest,
+    ): ApiResponse<TokenResponse>
+
+    // TODO : 여기 예시좀 적어주세요. 와일드카드 Response라 Swagger에 안잡혀요.
+    @Operation(summary = "토큰 재발급", description = "리프레시 토큰을 사용하여 새 액세스 토큰을 발급합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerResponse(
+                responseCode = "200",
+                description = "토큰 재발급 성공",
+            ),
+        ],
+    )
+    fun reIssue(
+        @Parameter(hidden = true) request: HttpServletRequest,
+        @Parameter(hidden = true) response: HttpServletResponse,
+    ): ApiResponse<*>
+
+    @Operation(summary = "로그아웃", description = "현재 로그인된 사용자를 로그아웃하고 리프레시 토큰 쿠키를 제거합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerResponse(
+                responseCode = "200",
+                description = "로그아웃 성공",
+            ),
+        ],
+    )
+    fun logout(
+        @Parameter(hidden = true) request: HttpServletRequest,
+        @Parameter(hidden = true) response: HttpServletResponse,
+        @AuthenticationPrincipal principalDetails: PrincipalDetails,
+    ): ApiResponse<Unit>
 }

--- a/pofo-api/src/main/kotlin/org/pofo/api/docs/UserApiDocs.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/docs/UserApiDocs.kt
@@ -1,0 +1,4 @@
+package org.pofo.api.docs
+
+class UserApiDocs {
+}

--- a/pofo-api/src/main/kotlin/org/pofo/api/security/SecurityConfig.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/security/SecurityConfig.kt
@@ -6,6 +6,7 @@ import org.pofo.api.security.jwt.JwtAuthenticationFilter
 import org.pofo.api.security.oauth2.OAuth2AuthenticationFailureHandler
 import org.pofo.api.security.oauth2.OAuth2AuthenticationService
 import org.pofo.api.security.oauth2.OAuth2AuthenticationSuccessHandler
+import org.pofo.common.response.Version
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -61,10 +62,10 @@ class SecurityConfig(
                     authorize("/graphiql", permitAll)
                 }
                 authorize(AntPathRequestMatcher("/graphql"), permitAll)
-                authorize(HttpMethod.POST, "/user", permitAll)
-                authorize(HttpMethod.POST, "/user/login", permitAll)
-                authorize(HttpMethod.POST, "/user/logout", permitAll)
-                authorize("/tech-stack/**", permitAll)
+                authorize(HttpMethod.POST, Version.V1 + "/user", permitAll)
+                authorize(HttpMethod.POST, Version.V1 + "/user/login", permitAll)
+                authorize(HttpMethod.POST, Version.V1 + "/user/logout", permitAll)
+                authorize(Version.V1 + "/tech-stack/**", permitAll)
                 authorize(anyRequest, authenticated)
             }
             exceptionHandling {

--- a/pofo-api/src/main/kotlin/org/pofo/api/security/SecurityConfig.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/security/SecurityConfig.kt
@@ -6,6 +6,7 @@ import org.pofo.api.security.jwt.JwtAuthenticationFilter
 import org.pofo.api.security.oauth2.OAuth2AuthenticationFailureHandler
 import org.pofo.api.security.oauth2.OAuth2AuthenticationService
 import org.pofo.api.security.oauth2.OAuth2AuthenticationSuccessHandler
+import org.pofo.common.response.Version
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -20,7 +21,6 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
@@ -54,23 +54,17 @@ class SecurityConfig(
             formLogin { disable() }
             httpBasic { disable() }
             authorizeHttpRequests {
-                authorize(AntPathRequestMatcher("/h2-console/**"), permitAll)
-                listOf("/graphql", "graphiql").forEach {
-                    authorize(it, permitAll)
-                }
-                listOf("/user", "/user/login", "/user/logout", "/user/re-issue").forEach {
-                    authorize(HttpMethod.POST, it, permitAll)
-                }
-                authorize("/tech-stack/**", permitAll)
                 if (isDevOrLocal) {
                     listOf("/graphql", "/graphiql", "/h2-console/**", "/v3/api-docs/**", "/swagger-ui/**").forEach {
                         authorize(it, permitAll)
                     }
                 }
-                listOf("/user", "/user/login", "/user/logout", "/user/re-issue").forEach {
-                    authorize(HttpMethod.POST, it, permitAll)
-                }
-                authorize("/tech-stack/**", permitAll)
+                listOf("/user", "/user/login", "/user/logout", "/user/re-issue")
+                    .map { "${Version.V1}$it" }
+                    .forEach {
+                        authorize(HttpMethod.POST, it, permitAll)
+                    }
+                authorize(Version.V1 + "/tech-stack/**", permitAll)
                 authorize(anyRequest, authenticated)
             }
             exceptionHandling {

--- a/pofo-api/src/main/resources/application.yml
+++ b/pofo-api/src/main/resources/application.yml
@@ -45,6 +45,7 @@ springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
   swagger-ui:
+    persist-authorization: true
     path: /swagger-ui
     disable-swagger-default-url: true
     display-request-duration: true

--- a/pofo-api/src/main/resources/application.yml
+++ b/pofo-api/src/main/resources/application.yml
@@ -41,6 +41,18 @@ logging:
     org.pofo.api: DEBUG
     org.springframework.security: DEBUG
 
+springdoc:
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: /swagger-ui
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+  api-docs:
+    groups:
+      enabled: true
+
 ---
 
 spring:
@@ -58,6 +70,18 @@ spring:
 logging:
   level:
     org.pofo.api: INFO
+
+springdoc:
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: /swagger-ui
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+  api-docs:
+    groups:
+      enabled: true
 
 ---
 

--- a/pofo-api/src/main/resources/application.yml
+++ b/pofo-api/src/main/resources/application.yml
@@ -75,6 +75,7 @@ springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
   swagger-ui:
+    persist-authorization: true
     path: /swagger-ui
     disable-swagger-default-url: true
     display-request-duration: true

--- a/pofo-api/src/test/kotlin/org/pofo/api/controller/UserControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/controller/UserControllerTest.kt
@@ -12,6 +12,7 @@ import org.pofo.api.security.jwt.JwtService
 import org.pofo.api.security.jwt.JwtTokenData
 import org.pofo.api.service.UserService
 import org.pofo.common.exception.ErrorCode
+import org.pofo.common.response.Version
 import org.pofo.domain.rds.domain.user.User
 import org.pofo.domain.redis.domain.accessToken.BannedAccessTokenRepository
 import org.springframework.beans.factory.annotation.Autowired
@@ -48,7 +49,7 @@ internal class UserControllerTest
 
                 it("유저 생성에 성공하고, 유저 조회에 성공해야 한다.") {
                     val resultActions =
-                        mockMvc.post("/user") {
+                        mockMvc.post(Version.V1 + "/user") {
                             contentType = MediaType.APPLICATION_JSON
                             content = objectMapper.writeValueAsString(requestBody)
                         }
@@ -68,7 +69,7 @@ internal class UserControllerTest
 
                     it("유저 생성이 실패해야 한다.") {
                         mockMvc
-                            .post("/user") {
+                            .post(Version.V1 + "/user") {
                                 contentType = MediaType.APPLICATION_JSON
                                 content = objectMapper.writeValueAsString(requestBody)
                             }.andExpect {
@@ -81,7 +82,7 @@ internal class UserControllerTest
 
             describe("로그인 시") {
                 fun jwtLogin(requestBody: LoginRequest): ResultActionsDsl =
-                    mockMvc.post("/user/login") {
+                    mockMvc.post(Version.V1 + "/user/login") {
                         contentType = MediaType.APPLICATION_JSON
                         content = objectMapper.writeValueAsString(requestBody)
                     }
@@ -131,7 +132,7 @@ internal class UserControllerTest
                     val accessToken = jwtService.generateAccessToken(JwtTokenData(savedUser))
 
                     mockMvc
-                        .post("/user/logout") {
+                        .post(Version.V1 + "/user/logout") {
                             contentType = MediaType.APPLICATION_JSON
                             headers {
                                 set(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
@@ -160,7 +161,7 @@ internal class UserControllerTest
 
                 it("내 정보가 반환된다.") {
                     mockMvc
-                        .get("/user/me") {
+                        .get(Version.V1 + "/user/me") {
                             headers {
                                 set(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
                             }

--- a/pofo-common/src/main/kotlin/org/pofo/common/response/Version.kt
+++ b/pofo-common/src/main/kotlin/org/pofo/common/response/Version.kt
@@ -1,0 +1,10 @@
+package org.pofo.common.response
+
+class Version {
+    companion object {
+        const val V1 = "/v1"
+        const val V2 = "/v2"
+        const val V3 = "/v3"
+        const val V4 = "/v4"
+    }
+}

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/user/User.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/user/User.java
@@ -24,8 +24,7 @@ public class User {
     @Column
     @NonNull
     private String password;
-
-    @JsonIgnore
+    
     @Column
     @NonNull
     @Enumerated(EnumType.STRING)

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/user/User.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/user/User.java
@@ -12,7 +12,8 @@ import org.springframework.lang.NonNull;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column
@@ -24,6 +25,7 @@ public class User {
     @NonNull
     private String password;
 
+    @JsonIgnore
     @Column
     @NonNull
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
## Overview

### Related Issue
Issue Number : #44 

## Task Details

Swagger API Docs를 추가했습니다. Token을 삽입할 수 있는 것을 상단에 넣어놨고, Swagger페이지에서는 브라우저를 새로고침해도 인증정보 유지하도록 설정했습니다.

또한, 공통응답 API Response를 만드면서 모든 Swagger가 공통응답으로 씹혀서 표시되는 현상이 있었는데, customizer 만들어서 wrapping해서 공통응답 스키마를 씹고 덮어쓰기 하도록 구성했습니다. (data field 부분만) (기존에는 data 필드가 전부 null로 표시됐었음.)

현재는 REST API가 몇개 되지 않아 단일 그룹화를 진행했지만, API 개수가 많아지면 Swagger Group화도 추후 고민해봐야 됩니다.

또한, 원래는 Controller와 Interface를 분리하지 않고, 그냥 API Docs만 따로 만들기로 했는데... 이게 제가 만들다 보니깐 이러면 Controller랑 Swagger랑 일관성이 없고 따로 놀 것 같다는 생각이 들어서 interface 형태로 만들었습니다. 추후, REST API도 이런식으로 개발해주시면 감사하겠습니다. 예시는 제가 많이 적어놨으니 보시면 됩니다. + Logic이 완벽하지 않더라도 Response가 어떻게 찍힐지 예상이 가는 API는 프론트가 미리 구조를 마련할 수 있도록 미리 틀을 마련해두는게 좋을 것 같습니다. Image Upload docs처럼 저런식으로 부탁드립니다.

https://dkswnkk.tistory.com/752

해당 글을 참고해주세용

또한, 앞으로의 개발을 위해 API Versioning 추가했습니다. API Version이 바뀌면 Decrepted 표시해주고 v2로 따로 파서 개발해주세요~

## Screenshots (Optional)
![image](https://github.com/user-attachments/assets/41ac4917-5c74-484d-b0e0-08843a9018e1)


## Review Requirements

토큰 재발급이랑 로그아웃 Response가 Type이 이상해서 Swagger 예시에 잘 안잡혀서 Example을 못적었습니다. 그 부분좀 적어주세요~
