### PR TITLE
hotfix: re-issue uri permitAll

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,8 +23,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.ACCESS_TOKEN }}
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/pofo-api/src/main/kotlin/org/pofo/api/security/SecurityConfig.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/security/SecurityConfig.kt
@@ -50,11 +50,12 @@ class SecurityConfig {
             httpBasic { disable() }
             authorizeHttpRequests {
                 authorize(AntPathRequestMatcher("/h2-console/**"), permitAll)
-                authorize(AntPathRequestMatcher("/graphql"), permitAll)
-                authorize("/graphiql", permitAll)
-                authorize(HttpMethod.POST, "/user", permitAll)
-                authorize(HttpMethod.POST, "/user/login", permitAll)
-                authorize(HttpMethod.POST, "/user/logout", permitAll)
+                listOf("/graphql", "graphiql").forEach {
+                    authorize(it, permitAll)
+                }
+                listOf("/user", "/user/login", "/user/logout", "/user/re-issue").forEach {
+                    authorize(HttpMethod.POST, it, permitAll)
+                }
                 authorize("/tech-stack/**", permitAll)
                 authorize(anyRequest, authenticated)
             }


### PR DESCRIPTION
## Overview

re-issue가 필요한 순간이 accessToken이 만료된 순간이므로 re-issue도 뚫어줘야 합니다.

### Related Issue
Issue Number : x

## Task Details

- listOf를 이용해서 여러 uri를 한번에 설정할 수 있도록 했습니다.

```kotlin
listOf("/graphql", "graphiql").forEach { 
    authorize(it, permitAll)
}
listOf("/user", "/user/login", "/user/logout", "/user/re-issue").forEach {
    authorize(HttpMethod.POST, it, permitAll)
}
```

## Review Requirements
