### PR TITLE
feat: 프로젝트 카테고리 다중화

### DIFF
--- a/pofo-api/src/main/kotlin/org/pofo/api/dto/ProjectCreateRequest.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/dto/ProjectCreateRequest.kt
@@ -1,6 +1,6 @@
 package org.pofo.api.dto
 
-import org.pofo.domain.rds.domain.project.ProjectCategory
+import org.pofo.domain.rds.domain.project.Category
 
 data class ProjectCreateRequest(
     val title: String,
@@ -9,7 +9,7 @@ data class ProjectCreateRequest(
     val keyImageIndex: Int? = null,
     val imageUrls: List<String>? = null,
     val content: String,
-    val category: ProjectCategory? = null,
+    val categories: List<Category>? = null,
     val stackNames: List<String>? = null,
     val isApproved: Boolean = false,
 )

--- a/pofo-api/src/main/kotlin/org/pofo/api/dto/ProjectResponse.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/dto/ProjectResponse.kt
@@ -12,7 +12,7 @@ data class ProjectResponse(
     val content: String,
     val isApproved: Boolean,
     val likes: Int,
-    val category: String?,
+    val categories: List<String>?,
     val stacks: List<String>?,
     val authorName: String,
 ) {
@@ -28,7 +28,7 @@ data class ProjectResponse(
                 project.content,
                 project.isApproved,
                 project.likes,
-                project.category?.name,
+                project.categories.map { it.category.name },
                 project.stacks.map { it.stack.name },
                 project.author.email,
             )

--- a/pofo-api/src/main/kotlin/org/pofo/api/dto/ProjectSearchRequest.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/dto/ProjectSearchRequest.kt
@@ -1,10 +1,10 @@
 package org.pofo.api.dto
 
-import org.pofo.domain.rds.domain.project.ProjectCategory
+import org.pofo.domain.rds.domain.project.Category
 
 data class ProjectSearchRequest(
     val title: String?,
-    val category: ProjectCategory?,
+    val categories: List<Category>?,
     val stackNames: List<String>?,
     val page: Int = 0,
     val size: Int = 30,

--- a/pofo-api/src/main/kotlin/org/pofo/api/dto/ProjectUpdateRequest.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/dto/ProjectUpdateRequest.kt
@@ -1,6 +1,6 @@
 package org.pofo.api.dto
 
-import org.pofo.domain.rds.domain.project.ProjectCategory
+import org.pofo.domain.rds.domain.project.Category
 
 data class ProjectUpdateRequest(
     val projectId: Long,
@@ -10,6 +10,6 @@ data class ProjectUpdateRequest(
     val imageUrls: List<String>? = null,
     val keyImageIndex: Int? = null,
     val content: String? = null,
-    val category: ProjectCategory? = null,
+    val categories: List<Category>? = null,
     val stackNames: List<String>? = null,
 )

--- a/pofo-api/src/main/kotlin/org/pofo/api/service/ProjectService.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/service/ProjectService.kt
@@ -66,12 +66,22 @@ class ProjectService(
                 .Bio(projectCreateRequest.bio)
                 .urls(projectCreateRequest.urls)
                 .imageUrls(projectCreateRequest.imageUrls)
+                .keyImageIndex(keyImageIndex)
                 .content(projectCreateRequest.content)
-                .category(projectCreateRequest.category)
                 .isApproved(projectCreateRequest.isApproved)
                 .author(author)
                 .build()
         val savedProject = projectRepository.save(project)
+
+        if (projectCreateRequest.stackNames != null) {
+            val foundStacks = stackRepository.findByNameIn(projectCreateRequest.stackNames)
+            logNotExistStacks(projectCreateRequest.stackNames, foundStacks)
+            project.updateStack(foundStacks)
+        }
+
+        if (projectCreateRequest.categories != null) {
+            project.updateCategories(projectCreateRequest.categories)
+        }
 
         return ProjectResponse.from(savedProject)
     }
@@ -98,12 +108,6 @@ class ProjectService(
             throw CustomException(ErrorCode.PROJECT_IMAGE_INDEX_ERROR)
         }
 
-        if (projectUpdateRequest.stackNames != null) {
-            val foundStacks = stackRepository.findByNameIn(projectUpdateRequest.stackNames)
-            logNotExistStacks(projectUpdateRequest.stackNames, foundStacks)
-            project.updateStack(foundStacks)
-        }
-
         val updatedProject =
             project.update(
                 projectUpdateRequest.title,
@@ -112,8 +116,17 @@ class ProjectService(
                 projectUpdateRequest.imageUrls,
                 projectUpdateRequest.keyImageIndex,
                 projectUpdateRequest.content,
-                projectUpdateRequest.category,
             )
+        if (projectUpdateRequest.stackNames != null) {
+            val foundStacks = stackRepository.findByNameIn(projectUpdateRequest.stackNames)
+            logNotExistStacks(projectUpdateRequest.stackNames, foundStacks)
+            project.updateStack(foundStacks)
+        }
+
+        if (projectUpdateRequest.categories != null) {
+            project.updateCategories(projectUpdateRequest.categories)
+        }
+
         return ProjectResponse.from(updatedProject)
     }
 
@@ -124,7 +137,7 @@ class ProjectService(
         val projectSlice =
             projectRepository.searchProjectWithQuery(
                 projectSearchRequest.title,
-                projectSearchRequest.category,
+                projectSearchRequest.categories,
                 projectSearchRequest.stackNames,
                 pageRequest,
             )

--- a/pofo-api/src/main/resources/graphql/project.graphqls
+++ b/pofo-api/src/main/resources/graphql/project.graphqls
@@ -8,7 +8,7 @@ type Project {
     content: String!
     isApproved: Boolean
     likes: Int
-    category: String
+    categories: [String]
     stacks: [String]
     authorName: String
 }
@@ -38,7 +38,7 @@ input ProjectCreateRequest {
     imageUrls: [String]
     keyImageIndex: Int
     content: String!
-    category: ProjectCategory
+    categories: [ProjectCategory]
     stackNames: [String]
     isApproved: Boolean! = false
 }
@@ -51,13 +51,13 @@ input ProjectUpdateRequest {
     imageUrls: [String]
     keyImageIndex: Int
     content: String
-    category: ProjectCategory
+    categories: [ProjectCategory]
     stackNames: [String]
 }
 
 input ProjectSearchRequest {
     title: String
-    category: ProjectCategory
+    categories: [ProjectCategory]
     stackNames: [String]
     page: Int! = 0
     size: Int! = 30

--- a/pofo-api/src/test/kotlin/org/pofo/api/controller/ProjectControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/controller/ProjectControllerTest.kt
@@ -212,7 +212,6 @@ internal class ProjectControllerTest
                     urls = project.urls,
                     keyImageIndex = 0,
                     imageUrls = project.imageUrls,
-                    category = project.category,
                     stackNames = null,
                 ),
                 authorId = authorId,

--- a/pofo-api/src/test/kotlin/org/pofo/api/fixture/ProjectFixture.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/fixture/ProjectFixture.kt
@@ -1,7 +1,6 @@
 package org.pofo.api.fixture
 
 import org.pofo.domain.rds.domain.project.Project
-import org.pofo.domain.rds.domain.project.ProjectCategory
 
 class ProjectFixture {
     companion object {
@@ -13,7 +12,6 @@ class ProjectFixture {
                 .content("취업좀 시켜줘라")
                 .urls(listOf("https://github.com/mclub4"))
                 .imageUrls(listOf("https://avatars.githubusercontent.com/u/55117706?v=4"))
-                .category(ProjectCategory.WEB)
                 .isApproved(false)
                 .build()
     }

--- a/pofo-api/src/test/resources/graphql-test/getProjectById.graphql
+++ b/pofo-api/src/test/resources/graphql-test/getProjectById.graphql
@@ -4,7 +4,7 @@ query getProjectById($projectId: ID!) {
         title
         bio
         content
-        category
+        categories
         authorName
     }
 }

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/Category.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/Category.java
@@ -1,0 +1,16 @@
+package org.pofo.domain.rds.domain.project;
+
+/**
+ * 프로젝트 유형
+ */
+public enum Category {
+    ALL,
+    WEB,
+    APP,
+    GAME,
+    GRAPHIC,
+    AI,
+    EMBEDDED,
+    LIBRARY,
+    ETC
+}

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/Project.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/Project.java
@@ -50,8 +50,9 @@ public class Project {
     private Boolean isApproved; // 모음팀 측에서 인증됬는지 (타 앱 연동을 통해)
 
     @Column
-    @Enumerated(EnumType.STRING)
-    private ProjectCategory category; // 프로젝트 유형
+    @Builder.Default
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectCategory> categories = new ArrayList<>(); // 프로젝트 유형
 
     @Setter
     @Builder.Default
@@ -78,7 +79,22 @@ public class Project {
         }
     }
 
-    public Project update(String title, String bio, List<String> urls, List<String> imageUrls, Integer keyImageIndex, String content, ProjectCategory category) {
+    public void addCategory(Category category) {
+        ProjectCategory projectCategory = ProjectCategory.builder()
+                .project(this)
+                .category(category)
+                .build();
+        this.categories.add(projectCategory);
+    }
+
+    public void updateCategories(List<Category> categories) {
+        this.categories.clear();
+        for (Category category : categories) {
+            this.addCategory(category);
+        }
+    }
+
+    public Project update(String title, String bio, List<String> urls, List<String> imageUrls, Integer keyImageIndex, String content) {
         if (title != null) {
             this.title = title;
         }
@@ -96,9 +112,6 @@ public class Project {
         }
         if (content != null) {
             this.content = content;
-        }
-        if (category != null) {
-            this.category = category;
         }
         return this;
     }

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/ProjectCategory.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/ProjectCategory.java
@@ -1,16 +1,24 @@
 package org.pofo.domain.rds.domain.project;
 
-/**
- * 프로젝트 유형
- */
-public enum ProjectCategory {
-    ALL,
-    WEB,
-    APP,
-    GAME,
-    GRAPHIC,
-    AI,
-    EMBEDDED,
-    LIBRARY,
-    ETC
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "project_category")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ProjectCategory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
 }

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/repository/ProjectCustomRepository.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/repository/ProjectCustomRepository.java
@@ -1,7 +1,7 @@
 package org.pofo.domain.rds.domain.project.repository;
 
 import org.pofo.domain.rds.domain.project.Project;
-import org.pofo.domain.rds.domain.project.ProjectCategory;
+import org.pofo.domain.rds.domain.project.Category;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -11,7 +11,7 @@ public interface ProjectCustomRepository {
     Slice<Project> searchProjectWithCursor(int size, Long cursor);
     Slice<Project> searchProjectWithQuery(
             String title,
-            ProjectCategory category,
+            List<Category> categories,
             List<String> stackNames,
             Pageable pageable
     );


### PR DESCRIPTION
## Overview

![image](https://github.com/user-attachments/assets/41307800-7f96-4025-b097-b87a31205bc3)

프로젝트의 카테고리를 다중화하였습니다.

### Related Issue
Issue Number : resolves #74 

## Task Details

![image](https://github.com/user-attachments/assets/6ebf5938-fa3c-43f6-9315-7ab697c70a34)

DB의 새로운 table인 `project_category` table을 생성해 프로젝트의 카테고리 리스트를 나타냈습니다.

이에 맞게 `ProjectUpdateRequest`와 `ProjectSearchRequest` 또한 맞게 변경되었습니다.

추가적으로 검색 기능에서 [WEB, APP] 으로 검색했을 때, 쿼리가 [WEB] 및 [APP] 단일 프로젝트 또한 검색되는 현상을 수정했습니다.

## Review Requirements

> [!WARNING]
> 리뷰어 휴가로 인한 바이패스 룰 적용