### PR TITLE
feat: 좋아요 기능 구현

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,4 @@ indent_style = space
 trim_trailing_whitespace = true
 insert_final_newline = true
 max_line_length = 120
+ktlint.no-wildcard-imports = false

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ data_crawling/ProjectStack.java
 data_crawling/project.stack.graphqls
 
 .env
+generated

--- a/pofo-api/build.gradle.kts
+++ b/pofo-api/build.gradle.kts
@@ -32,4 +32,7 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
 
     implementation("com.google.cloud.sql:postgres-socket-factory:1.21.2")
+
+    implementation("org.springframework.retry:spring-retry")
+    implementation("org.springframework:spring-aspects")
 }

--- a/pofo-api/src/main/kotlin/org/pofo/api/ApiApplication.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/ApiApplication.kt
@@ -4,7 +4,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration
 import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration
 import org.springframework.boot.runApplication
+import org.springframework.retry.annotation.EnableRetry
 
+@EnableRetry
 @SpringBootApplication(
     exclude = [ElasticsearchDataAutoConfiguration::class, ElasticsearchRestClientAutoConfiguration::class],
 )

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeApiDocs.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeApiDocs.kt
@@ -1,0 +1,42 @@
+package org.pofo.api.domain.like
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.pofo.api.common.response.ApiResponse
+import org.pofo.api.domain.security.PrincipalDetails
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerResponse
+
+@Tag(name = "[Like API]", description = "좋아요 관련 API")
+interface LikeApiDocs {
+    @Operation(summary = "좋아요 등록", description = "특정 프로젝트에 좋아요를 등록합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerResponse(
+                responseCode = "200",
+                description = "좋아요 등록 성공",
+            ),
+        ],
+    )
+    fun likeProject(
+        @Parameter(hidden = true) @AuthenticationPrincipal principalDetails: PrincipalDetails,
+        @PathVariable("projectId") projectId: Long,
+    ): ApiResponse<Unit>
+
+    @Operation(summary = "좋아요 해제", description = "특정 프로젝트에 등록된 좋아요를 해제합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerResponse(
+                responseCode = "200",
+                description = "좋아요 해제 성공",
+            ),
+        ],
+    )
+    fun unlikeProject(
+        @Parameter(hidden = true) @AuthenticationPrincipal principalDetails: PrincipalDetails,
+        @PathVariable("projectId") projectId: Long,
+    ): ApiResponse<Unit>
+}

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeApiDocs.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeApiDocs.kt
@@ -24,7 +24,7 @@ interface LikeApiDocs {
     fun likeProject(
         @Parameter(hidden = true) @AuthenticationPrincipal principalDetails: PrincipalDetails,
         @PathVariable("projectId") projectId: Long,
-    ): ApiResponse<Unit>
+    ): ApiResponse<Map<String, Int>>
 
     @Operation(summary = "좋아요 해제", description = "특정 프로젝트에 등록된 좋아요를 해제합니다.")
     @ApiResponses(
@@ -38,5 +38,5 @@ interface LikeApiDocs {
     fun unlikeProject(
         @Parameter(hidden = true) @AuthenticationPrincipal principalDetails: PrincipalDetails,
         @PathVariable("projectId") projectId: Long,
-    ): ApiResponse<Unit>
+    ): ApiResponse<Map<String, Int>>
 }

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeController.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeController.kt
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping(Version.V1 + "/likes")
+@RequestMapping(Version.V1 + "/like")
 class LikeController(
     private val likeService: LikeService,
 ) : LikeApiDocs {

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeController.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeController.kt
@@ -1,0 +1,31 @@
+package org.pofo.api.domain.like
+
+import org.pofo.api.common.response.ApiResponse
+import org.pofo.api.domain.security.PrincipalDetails
+import org.pofo.common.response.Version
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping(Version.V1 + "/likes")
+class LikeController(
+    private val likeService: LikeService,
+) : LikeApiDocs {
+    @PostMapping("/{projectId}")
+    override fun likeProject(
+        @AuthenticationPrincipal principalDetails: PrincipalDetails,
+        @PathVariable projectId: Long,
+    ): ApiResponse<Unit> {
+        likeService.likeProject(principalDetails.jwtTokenData.userId, projectId)
+        return ApiResponse.success(Unit)
+    }
+
+    @DeleteMapping("/{projectId}")
+    override fun unlikeProject(
+        @AuthenticationPrincipal principalDetails: PrincipalDetails,
+        @PathVariable projectId: Long,
+    ): ApiResponse<Unit> {
+        likeService.unlikeProject(principalDetails.jwtTokenData.userId, projectId)
+        return ApiResponse.success(Unit)
+    }
+}

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeController.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeController.kt
@@ -15,17 +15,17 @@ class LikeController(
     override fun likeProject(
         @AuthenticationPrincipal principalDetails: PrincipalDetails,
         @PathVariable projectId: Long,
-    ): ApiResponse<Unit> {
-        likeService.likeProject(principalDetails.jwtTokenData.userId, projectId)
-        return ApiResponse.success(Unit)
+    ): ApiResponse<Map<String, Int>> {
+        val currentLikes = likeService.likeProject(principalDetails.jwtTokenData.userId, projectId)
+        return ApiResponse.success(mapOf("likes" to currentLikes))
     }
 
     @DeleteMapping("/{projectId}")
     override fun unlikeProject(
         @AuthenticationPrincipal principalDetails: PrincipalDetails,
         @PathVariable projectId: Long,
-    ): ApiResponse<Unit> {
-        likeService.unlikeProject(principalDetails.jwtTokenData.userId, projectId)
-        return ApiResponse.success(Unit)
+    ): ApiResponse<Map<String, Int>> {
+        val currentLikes = likeService.unlikeProject(principalDetails.jwtTokenData.userId, projectId)
+        return ApiResponse.success(mapOf("likes" to currentLikes))
     }
 }

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeController.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeController.kt
@@ -4,7 +4,11 @@ import org.pofo.api.common.response.ApiResponse
 import org.pofo.api.domain.security.PrincipalDetails
 import org.pofo.common.response.Version
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping(Version.V1 + "/likes")

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeService.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeService.kt
@@ -4,7 +4,6 @@ import org.pofo.common.exception.CustomException
 import org.pofo.common.exception.ErrorCode
 import org.pofo.domain.rds.domain.like.Like
 import org.pofo.domain.rds.domain.like.LikeRepository
-import org.pofo.domain.rds.domain.project.Project
 import org.pofo.domain.rds.domain.project.repository.ProjectRepository
 import org.pofo.domain.rds.domain.user.UserRepository
 import org.springframework.stereotype.Service
@@ -21,7 +20,7 @@ class LikeService(
     fun likeProject(
         userId: Long,
         projectId: Long,
-    ) {
+    ): Int {
         val user =
             userRepository.findById(userId)
                 ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
@@ -42,13 +41,14 @@ class LikeService(
                 .build()
         likeRepository.save(like)
         project.increaseLikes()
+        return project.likes
     }
 
     @Transactional
     fun unlikeProject(
         userId: Long,
         projectId: Long,
-    ) {
+    ): Int {
         val user =
             userRepository.findById(userId)
                 ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
@@ -63,12 +63,6 @@ class LikeService(
 
         likeRepository.delete(like)
         project.decreaseLikes()
-    }
-
-    fun getLikedProjects(userId: Long): List<Project> {
-        val user =
-            userRepository.findById(userId)
-                ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
-        return likeRepository.findLikedProjectsByUser(user)
+        return project.likes
     }
 }

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeService.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeService.kt
@@ -8,6 +8,8 @@ import org.pofo.domain.rds.domain.like.LikeRepository
 import org.pofo.domain.rds.domain.project.repository.ProjectRepository
 import org.pofo.domain.rds.domain.user.UserRepository
 import org.springframework.dao.OptimisticLockingFailureException
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -18,61 +20,73 @@ class LikeService(
     private val projectRepository: ProjectRepository,
     private val userRepository: UserRepository,
 ) {
+    @Retryable(
+        value = [OptimisticLockingFailureException::class, StaleObjectStateException::class],
+        maxAttempts = 10,
+        backoff = Backoff(delay = 50, multiplier = 2.0),
+    )
     @Transactional
     fun likeProject(
         userId: Long,
         projectId: Long,
-    ): Int =
-        retryOptimisticLock {
-            val user =
-                userRepository.findById(userId)
-                    ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+    ): Int {
+        val user =
+            userRepository.findById(userId)
+                ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-            val project =
-                projectRepository.findById(projectId)
-                    ?: throw CustomException(ErrorCode.PROJECT_NOT_FOUND)
+        val project =
+            projectRepository.findById(projectId)
+                ?: throw CustomException(ErrorCode.PROJECT_NOT_FOUND)
 
-            if (likeRepository.existsByUserAndProject(user, project)) {
-                throw CustomException(ErrorCode.ALREADY_LIKED_PROJECT)
-            }
-
-            val like =
-                Like
-                    .builder()
-                    .project(project)
-                    .user(user)
-                    .build()
-            likeRepository.saveAndFlush(like) // 즉시 저장 및 반영
-            project.increaseLikes()
-            project.likes
+        if (likeRepository.existsByUserAndProject(user, project)) {
+            throw CustomException(ErrorCode.ALREADY_LIKED_PROJECT)
         }
 
+        val like =
+            Like
+                .builder()
+                .project(project)
+                .user(user)
+                .build()
+        project.increaseLikes()
+        projectRepository.save(project)
+        likeRepository.save(like)
+        return project.likes
+    }
+
+    @Retryable(
+        value = [OptimisticLockingFailureException::class, StaleObjectStateException::class],
+        maxAttempts = 10,
+        backoff = Backoff(delay = 50, multiplier = 2.0),
+    )
     @Transactional
     fun unlikeProject(
         userId: Long,
         projectId: Long,
-    ): Int =
-        retryOptimisticLock {
-            val user =
-                userRepository.findById(userId)
-                    ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+    ): Int {
+        val user =
+            userRepository.findById(userId)
+                ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-            val project =
-                projectRepository.findById(projectId)
-                    ?: throw CustomException(ErrorCode.PROJECT_NOT_FOUND)
+        val project =
+            projectRepository.findById(projectId)
+                ?: throw CustomException(ErrorCode.PROJECT_NOT_FOUND)
 
-            val like =
-                likeRepository.findByUserAndProject(user, project)
-                    ?: throw CustomException(ErrorCode.LIKE_NOT_FOUND)
+        val like =
+            likeRepository.findByUserAndProject(user, project)
+                ?: throw CustomException(ErrorCode.LIKE_NOT_FOUND)
 
-            likeRepository.delete(like)
-            project.decreaseLikes()
-            project.likes
-        }
+        project.decreaseLikes()
+        projectRepository.save(project)
+        likeRepository.delete(like)
+        return project.likes
+    }
 
+    @Deprecated(message = "이유를 모르겠으나 제대로 작동안하는 재시도 로직. 참고용으로 남김")
     private fun <T> retryOptimisticLock(action: () -> T): T {
         var attempts = 0
-        val maxRetries = 5
+        val maxRetries = 10
+        var waitTime = 50L
         while (true) {
             try {
                 return action()
@@ -80,13 +94,12 @@ class LikeService(
                 if (++attempts > maxRetries) {
                     throw CustomException(ErrorCode.LIKE_FAILED)
                 }
-                Thread.sleep(50)
             } catch (ex: StaleObjectStateException) {
                 if (++attempts > maxRetries) {
                     throw CustomException(ErrorCode.LIKE_FAILED)
                 }
-                Thread.sleep(50)
             }
+            Thread.sleep(waitTime)
         }
     }
 }

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeService.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeService.kt
@@ -1,11 +1,13 @@
 package org.pofo.api.domain.like
 
+import org.hibernate.StaleObjectStateException
 import org.pofo.common.exception.CustomException
 import org.pofo.common.exception.ErrorCode
 import org.pofo.domain.rds.domain.like.Like
 import org.pofo.domain.rds.domain.like.LikeRepository
 import org.pofo.domain.rds.domain.project.repository.ProjectRepository
 import org.pofo.domain.rds.domain.user.UserRepository
+import org.springframework.dao.OptimisticLockingFailureException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -20,49 +22,71 @@ class LikeService(
     fun likeProject(
         userId: Long,
         projectId: Long,
-    ): Int {
-        val user =
-            userRepository.findById(userId)
-                ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+    ): Int =
+        retryOptimisticLock {
+            val user =
+                userRepository.findById(userId)
+                    ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-        val project =
-            projectRepository.findById(projectId)
-                ?: throw CustomException(ErrorCode.PROJECT_NOT_FOUND)
+            val project =
+                projectRepository.findById(projectId)
+                    ?: throw CustomException(ErrorCode.PROJECT_NOT_FOUND)
 
-        if (likeRepository.existsByUserAndProject(user, project)) {
-            throw CustomException(ErrorCode.ALREADY_LIKED_PROJECT)
+            if (likeRepository.existsByUserAndProject(user, project)) {
+                throw CustomException(ErrorCode.ALREADY_LIKED_PROJECT)
+            }
+
+            val like =
+                Like
+                    .builder()
+                    .project(project)
+                    .user(user)
+                    .build()
+            likeRepository.saveAndFlush(like) // 즉시 저장 및 반영
+            project.increaseLikes()
+            project.likes
         }
-
-        val like =
-            Like
-                .builder()
-                .project(project)
-                .user(user)
-                .build()
-        likeRepository.save(like)
-        project.increaseLikes()
-        return project.likes
-    }
 
     @Transactional
     fun unlikeProject(
         userId: Long,
         projectId: Long,
-    ): Int {
-        val user =
-            userRepository.findById(userId)
-                ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+    ): Int =
+        retryOptimisticLock {
+            val user =
+                userRepository.findById(userId)
+                    ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-        val project =
-            projectRepository.findById(projectId)
-                ?: throw CustomException(ErrorCode.PROJECT_NOT_FOUND)
+            val project =
+                projectRepository.findById(projectId)
+                    ?: throw CustomException(ErrorCode.PROJECT_NOT_FOUND)
 
-        val like =
-            likeRepository.findByUserAndProject(user, project)
-                ?: throw CustomException(ErrorCode.LIKE_NOT_FOUND)
+            val like =
+                likeRepository.findByUserAndProject(user, project)
+                    ?: throw CustomException(ErrorCode.LIKE_NOT_FOUND)
 
-        likeRepository.delete(like)
-        project.decreaseLikes()
-        return project.likes
+            likeRepository.delete(like)
+            project.decreaseLikes()
+            project.likes
+        }
+
+    private fun <T> retryOptimisticLock(action: () -> T): T {
+        var attempts = 0
+        val maxRetries = 5
+        while (true) {
+            try {
+                return action()
+            } catch (ex: OptimisticLockingFailureException) {
+                if (++attempts > maxRetries) {
+                    throw CustomException(ErrorCode.LIKE_FAILED)
+                }
+                Thread.sleep(50)
+            } catch (ex: StaleObjectStateException) {
+                if (++attempts > maxRetries) {
+                    throw CustomException(ErrorCode.LIKE_FAILED)
+                }
+                Thread.sleep(50)
+            }
+        }
     }
 }

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeService.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeService.kt
@@ -31,7 +31,7 @@ class LikeService(
                 ?: throw CustomException(ErrorCode.PROJECT_NOT_FOUND)
 
         if (likeRepository.existsByUserAndProject(user, project)) {
-            throw IllegalStateException("이미 좋아요를 누른 프로젝트입니다. (Project ID: $projectId)")
+            throw CustomException(ErrorCode.ALREADY_LIKED_PROJECT)
         }
 
         val like =

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeService.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeService.kt
@@ -1,0 +1,70 @@
+package org.pofo.api.domain.like
+
+import org.pofo.domain.rds.domain.like.LikeRepository
+import org.pofo.domain.rds.domain.project.repository.ProjectRepository
+import org.pofo.domain.rds.domain.user.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class LikeService(
+    private val likeRepository: LikeRepository,
+    private val projectRepository: ProjectRepository,
+    private val userRepository: UserRepository,
+) {
+    @Transactional
+    fun likeProject(
+        userId: Long,
+        projectId: Long,
+    ) {
+        val user =
+            userRepository
+                .findById(userId)
+                .orElseThrow { IllegalArgumentException("사용자를 찾을 수 없습니다.") }
+        val project =
+            projectRepository
+                .findById(projectId)
+                .orElseThrow { IllegalArgumentException("프로젝트를 찾을 수 없습니다.") }
+
+        if (likeRepository.existsByUserAndProject(user, project)) {
+            throw IllegalStateException("이미 좋아요를 누른 프로젝트입니다.")
+        }
+
+        val like = Like.createLike(user, project)
+        likeRepository.save(like)
+        project.increaseLikes()
+    }
+
+    @Transactional
+    fun unlikeProject(
+        userId: Long,
+        projectId: Long,
+    ) {
+        val user =
+            userRepository
+                .findById(userId)
+                .orElseThrow { IllegalArgumentException("사용자를 찾을 수 없습니다.") }
+        val project =
+            projectRepository
+                .findById(projectId)
+                .orElseThrow { IllegalArgumentException("프로젝트를 찾을 수 없습니다.") }
+
+        val like =
+            likeRepository
+                .findByUserAndProject(user, project)
+                .orElseThrow { IllegalStateException("좋아요가 존재하지 않습니다.") }
+
+        likeRepository.delete(like)
+        project.decreaseLikes()
+    }
+
+    @Transactional(readOnly = true)
+    fun getLikedProjects(userId: Long): List<Project> {
+        val user =
+            userRepository
+                .findById(userId)
+                .orElseThrow { IllegalArgumentException("사용자를 찾을 수 없습니다.") }
+
+        return likeRepository.findLikedProjectsByUser(user)
+    }
+}

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/like/LikeControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/like/LikeControllerTest.kt
@@ -144,7 +144,9 @@ class LikeControllerTest
 
             describe("좋아요 동시성 테스트") {
                 it("동시 요청에서도 좋아요 수가 정확히 관리된다") {
-                    val likeCount = 10
+                    val likeCount = 80
+
+                    // 모든 스레드가 동시에 시작되도록 제어해서 동시성 처리 테스트
                     val latch = CountDownLatch(likeCount)
                     val executor = Executors.newFixedThreadPool(likeCount)
 
@@ -159,9 +161,11 @@ class LikeControllerTest
                         }
                     }
 
+                    // 스레드가 모두 끝날때 까지 대기
                     latch.await()
                     executor.shutdown()
 
+                    // DB에 조회 한번 해봐서 제대로 값이 나왔는지 확인
                     val updatedProject =
                         projectRepository.findById(project.id!!)
                             ?: throw CustomException(ErrorCode.PROJECT_NOT_FOUND)

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/like/LikeControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/like/LikeControllerTest.kt
@@ -1,4 +1,171 @@
 package org.pofo.api.domain.like
 
-class LikeControllerTest {
-}
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import org.pofo.api.domain.security.jwt.JwtService
+import org.pofo.api.domain.security.jwt.JwtTokenData
+import org.pofo.api.fixture.ProjectFixture
+import org.pofo.api.fixture.UserFixture
+import org.pofo.common.exception.CustomException
+import org.pofo.common.exception.ErrorCode
+import org.pofo.common.response.Version
+import org.pofo.domain.rds.domain.like.Like
+import org.pofo.domain.rds.domain.like.LikeRepository
+import org.pofo.domain.rds.domain.project.Project
+import org.pofo.domain.rds.domain.project.repository.ProjectRepository
+import org.pofo.domain.rds.domain.user.User
+import org.pofo.domain.rds.domain.user.UserRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.post
+import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class LikeControllerTest
+    @Autowired
+    constructor(
+        private val mockMvc: MockMvc,
+        private val userRepository: UserRepository,
+        private val projectRepository: ProjectRepository,
+        private val likeRepository: LikeRepository,
+        private val jwtService: JwtService,
+    ) : DescribeSpec({
+            extensions(
+                SpringExtension,
+            )
+
+            val objectMapper =
+                jacksonObjectMapper()
+
+            lateinit var user: User
+            lateinit var project: Project
+            lateinit var accessToken: String
+
+            beforeEach {
+                user = userRepository.save(UserFixture.createUser())
+                project =
+                    projectRepository.save(ProjectFixture.createProject())
+
+                accessToken =
+                    jwtService.generateAccessToken(
+                        JwtTokenData(
+                            user,
+                        ),
+                    )
+            }
+
+            describe("좋아요 등록") {
+                it("성공적으로 좋아요를 등록한다") {
+                    val result =
+                        mockMvc
+                            .post("${Version.V1}/likes/${project.id}") {
+                                contentType = MediaType.APPLICATION_JSON
+                                headers { set(HttpHeaders.AUTHORIZATION, "Bearer $accessToken") }
+                            }.andExpect {
+                                status { isOk() }
+                                jsonPath("$.data.likes") { value(1) }
+                            }
+
+                    likeRepository.existsByUserAndProject(user, project) shouldBe true
+                }
+
+                it("중복된 좋아요 등록 시 실패한다") {
+                    // Given
+                    likeRepository.save(
+                        Like
+                            .builder()
+                            .user(user)
+                            .project(project)
+                            .build(),
+                    )
+
+                    // When
+                    val result =
+                        mockMvc
+                            .post("${Version.V1}/likes/${project.id}") {
+                                contentType = MediaType.APPLICATION_JSON
+                                headers { set(HttpHeaders.AUTHORIZATION, "Bearer $accessToken") }
+                            }.andExpect {
+                                status { isBadRequest() }
+                                jsonPath("$.code") { value(ErrorCode.ALREADY_LIKED_PROJECT.code) }
+                            }
+                }
+            }
+
+            describe("좋아요 해제") {
+                it("성공적으로 좋아요를 해제한다") {
+                    // Given
+                    likeRepository.save(
+                        Like
+                            .builder()
+                            .user(user)
+                            .project(project)
+                            .build(),
+                    )
+
+                    // When
+                    mockMvc
+                        .delete("${Version.V1}/likes/${project.id}") {
+                            contentType = MediaType.APPLICATION_JSON
+                            headers { set(HttpHeaders.AUTHORIZATION, "Bearer $accessToken") }
+                        }.andExpect {
+                            status { isOk() }
+                            jsonPath("$.data.likes") { value(0) }
+                        }
+
+                    // Then
+                    likeRepository.existsByUserAndProject(user, project) shouldBe false
+                }
+
+                it("좋아요가 없는 상태에서 해제 시 실패한다") {
+                    mockMvc
+                        .delete("${Version.V1}/likes/${project.id}") {
+                            contentType = MediaType.APPLICATION_JSON
+                            headers { set(HttpHeaders.AUTHORIZATION, "Bearer $accessToken") }
+                        }.andExpect {
+                            status { isBadRequest() }
+                            jsonPath("$.code") { value(ErrorCode.LIKE_NOT_FOUND.code) }
+                        }
+                }
+            }
+
+            describe("좋아요 동시성 테스트") {
+                it("동시 요청에서도 좋아요 수가 정확히 관리된다") {
+                    val likeCount = 10
+                    val latch = CountDownLatch(likeCount)
+                    val executor = Executors.newFixedThreadPool(likeCount)
+
+                    repeat(likeCount) {
+                        executor.submit {
+                            try {
+                                project.increaseLikes()
+                                projectRepository.saveAndFlush(project)
+                            } finally {
+                                latch.countDown()
+                            }
+                        }
+                    }
+
+                    latch.await()
+                    executor.shutdown()
+
+                    val updatedProject =
+                        projectRepository.findById(project.id!!)
+                            ?: throw CustomException(ErrorCode.PROJECT_NOT_FOUND)
+                    updatedProject.likes shouldBe likeCount
+                }
+            }
+        })

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/like/LikeControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/like/LikeControllerTest.kt
@@ -7,7 +7,6 @@ import io.kotest.matchers.shouldBe
 import org.pofo.api.domain.security.jwt.JwtService
 import org.pofo.api.domain.security.jwt.JwtTokenData
 import org.pofo.api.fixture.ProjectFixture
-import org.pofo.api.fixture.UserFixture
 import org.pofo.common.exception.CustomException
 import org.pofo.common.exception.ErrorCode
 import org.pofo.common.response.Version
@@ -17,6 +16,7 @@ import org.pofo.domain.rds.domain.project.Project
 import org.pofo.domain.rds.domain.project.repository.ProjectRepository
 import org.pofo.domain.rds.domain.user.User
 import org.pofo.domain.rds.domain.user.UserRepository
+import org.pofo.domain.rds.domain.user.UserRole
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -26,12 +26,10 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.post
-import org.springframework.transaction.annotation.Transactional
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 
 @SpringBootTest
-@Transactional
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 class LikeControllerTest
@@ -56,16 +54,30 @@ class LikeControllerTest
             lateinit var accessToken: String
 
             beforeEach {
-                user = userRepository.save(UserFixture.createUser())
+                user =
+                    userRepository.save(
+                        User
+                            .builder()
+                            .email("${System.currentTimeMillis()}-example@org.com")
+                            .password("testPassword")
+                            .role(UserRole.ROLE_USER)
+                            .username("${System.currentTimeMillis()}-TEST")
+                            .build(),
+                    )
                 project =
                     projectRepository.save(ProjectFixture.createProject())
-
                 accessToken =
                     jwtService.generateAccessToken(
                         JwtTokenData(
                             user,
                         ),
                     )
+            }
+
+            afterSpec {
+                likeRepository.deleteAll()
+                projectRepository.deleteAll()
+                userRepository.deleteAll()
             }
 
             describe("좋아요 등록") {
@@ -151,27 +163,14 @@ class LikeControllerTest
                     val latch = CountDownLatch(likeCount)
                     val executor = Executors.newFixedThreadPool(likeCount)
 
-                    val newUser =
-                        userRepository.saveAndFlush(
-                            User
-                                .builder()
-                                .email("test@naver.com")
-                                .password("123gjs21@d")
-                                .username("testnamerr")
-                                .build(),
-                        )
-                    val newProject =
-                        projectRepository.save(ProjectFixture.createProject())
-
-                    val test = userRepository.findById(newUser.id)
-
                     repeat(likeCount) {
                         executor.submit {
                             try {
-                                likeService.likeProject(newUser.id, newProject.id)
+                                likeService.likeProject(user.id, project.id)
                             } catch (ex: Exception) {
                                 println(
-                                    "User ID: ${test.id}, Project ID: ${newProject.id} - Exception in thread ${Thread.currentThread().name}: ${ex.message}",
+                                    "User ID: ${user.id}, Project ID: ${project.id} - " +
+                                        "Exception in thread ${Thread.currentThread().name}: ${ex.message}",
                                 )
                             } finally {
                                 latch.countDown()
@@ -185,7 +184,7 @@ class LikeControllerTest
 
                     // DB에 조회 한번 해봐서 제대로 값이 나왔는지 확인
                     val updatedProject =
-                        projectRepository.findById(newProject.id!!)
+                        projectRepository.findById(project.id!!)
                             ?: throw CustomException(ErrorCode.PROJECT_NOT_FOUND)
                     updatedProject.likes shouldBe likeCount
                 }

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/like/LikeControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/like/LikeControllerTest.kt
@@ -1,0 +1,4 @@
+package org.pofo.api.domain.like
+
+class LikeControllerTest {
+}

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/like/LikeControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/like/LikeControllerTest.kt
@@ -84,7 +84,7 @@ class LikeControllerTest
                 it("성공적으로 좋아요를 등록한다") {
                     val result =
                         mockMvc
-                            .post("${Version.V1}/likes/${project.id}") {
+                            .post("${Version.V1}/like/${project.id}") {
                                 contentType = MediaType.APPLICATION_JSON
                                 headers { set(HttpHeaders.AUTHORIZATION, "Bearer $accessToken") }
                             }.andExpect {
@@ -108,7 +108,7 @@ class LikeControllerTest
                     // When
                     val result =
                         mockMvc
-                            .post("${Version.V1}/likes/${project.id}") {
+                            .post("${Version.V1}/like/${project.id}") {
                                 contentType = MediaType.APPLICATION_JSON
                                 headers { set(HttpHeaders.AUTHORIZATION, "Bearer $accessToken") }
                             }.andExpect {
@@ -131,7 +131,7 @@ class LikeControllerTest
 
                     // When
                     mockMvc
-                        .delete("${Version.V1}/likes/${project.id}") {
+                        .delete("${Version.V1}/like/${project.id}") {
                             contentType = MediaType.APPLICATION_JSON
                             headers { set(HttpHeaders.AUTHORIZATION, "Bearer $accessToken") }
                         }.andExpect {
@@ -145,7 +145,7 @@ class LikeControllerTest
 
                 it("좋아요가 없는 상태에서 해제 시 실패한다") {
                     mockMvc
-                        .delete("${Version.V1}/likes/${project.id}") {
+                        .delete("${Version.V1}/like/${project.id}") {
                             contentType = MediaType.APPLICATION_JSON
                             headers { set(HttpHeaders.AUTHORIZATION, "Bearer $accessToken") }
                         }.andExpect {

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/like/LikeControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/like/LikeControllerTest.kt
@@ -168,7 +168,7 @@ class LikeControllerTest
                     repeat(likeCount) {
                         executor.submit {
                             try {
-                                likeService.likeProject(newUser.id, newProject.id)
+                                likeService.likeProject(test.id, newProject.id)
                             } catch (ex: Exception) {
                                 println(
                                     "User ID: ${test.id}, Project ID: ${newProject.id} - Exception in thread ${Thread.currentThread().name}: ${ex.message}",

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/like/LikeControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/like/LikeControllerTest.kt
@@ -157,21 +157,31 @@ class LikeControllerTest
 
             describe("좋아요 동시성 테스트") {
                 it("동시 요청에서도 좋아요 수가 정확히 관리된다") {
-                    val likeCount = 1
+                    val likeCount = 10
+
+                    val users =
+                        (1..likeCount).map {
+                            userRepository.save(
+                                User
+                                    .builder()
+                                    .email("user$it@example.com")
+                                    .password("testPassword")
+                                    .role(UserRole.ROLE_USER)
+                                    .username("user$it")
+                                    .build(),
+                            )
+                        }
 
                     // 모든 스레드가 동시에 시작되도록 제어해서 동시성 처리 테스트
                     val latch = CountDownLatch(likeCount)
                     val executor = Executors.newFixedThreadPool(likeCount)
 
-                    repeat(likeCount) {
+                    users.forEach { user ->
                         executor.submit {
                             try {
                                 likeService.likeProject(user.id, project.id)
                             } catch (ex: Exception) {
-                                println(
-                                    "User ID: ${user.id}, Project ID: ${project.id} - " +
-                                        "Exception in thread ${Thread.currentThread().name}: ${ex.message}",
-                                )
+                                println("Exception for User ID: ${user.id}, Project ID: ${project.id} -> ${ex.message}")
                             } finally {
                                 latch.countDown()
                             }

--- a/pofo-common/src/main/kotlin/org/pofo/common/exception/CustomException.kt
+++ b/pofo-common/src/main/kotlin/org/pofo/common/exception/CustomException.kt
@@ -1,7 +1,7 @@
 package org.pofo.common.exception
 
-class CustomException(val errorCode: ErrorCode) : RuntimeException(errorCode.message) {
-    override fun fillInStackTrace(): Throwable {
-        return this
-    }
+class CustomException(
+    val errorCode: ErrorCode,
+) : RuntimeException(errorCode.message) {
+    override fun fillInStackTrace(): Throwable = this
 }

--- a/pofo-common/src/main/kotlin/org/pofo/common/exception/ErrorCode.kt
+++ b/pofo-common/src/main/kotlin/org/pofo/common/exception/ErrorCode.kt
@@ -25,4 +25,5 @@ enum class ErrorCode(
     // Like
     LIKE_NOT_FOUND(400, "기존에 좋아요가 존재하지 않습니다.", "LIKE-001"),
     ALREADY_LIKED_PROJECT(400, "이미 좋아요를 누른 글입니다.", "LIKE-002"),
+    LIKE_FAILED(400, "좋아요를 실패했습니다", "LIKE-003"),
 }

--- a/pofo-common/src/main/kotlin/org/pofo/common/exception/ErrorCode.kt
+++ b/pofo-common/src/main/kotlin/org/pofo/common/exception/ErrorCode.kt
@@ -21,4 +21,8 @@ enum class ErrorCode(
     PROJECT_NOT_FOUND(404, "프로젝트를 찾을 수 없습니다.", "PROJ-001"),
     PROJECT_STACK_NOT_FOUND(400, "프로젝트 스택을 찾을 수 없습니다.", "PROJ-002"),
     PROJECT_IMAGE_INDEX_ERROR(400, "대표 이미지 인덱스가 잘못되었습니다.", "PROJ-003"),
+
+    // Like
+    LIKE_NOT_FOUND(400, "기존에 좋아요가 존재하지 않습니다.", "LIKE-001"),
+    ALREADY_LIKED_PROJECT(400, "이미 좋아요를 누른 글입니다.", "LIKE-002"),
 }

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/like/Like.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/like/Like.java
@@ -1,0 +1,27 @@
+package org.pofo.domain.rds.domain.like;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.pofo.domain.rds.domain.project.Project;
+import org.pofo.domain.rds.domain.user.User;
+
+@Entity
+@Table(name = "like")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Like {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+}

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/like/Like.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/like/Like.java
@@ -6,7 +6,7 @@ import org.pofo.domain.rds.domain.project.Project;
 import org.pofo.domain.rds.domain.user.User;
 
 @Entity
-@Table(name = "like")
+@Table(name = "\"like\"")
 @Getter
 @Builder
 @AllArgsConstructor

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/like/LikeRepository.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/like/LikeRepository.java
@@ -1,0 +1,19 @@
+package org.pofo.domain.rds.domain.like;
+
+import io.lettuce.core.dynamic.annotation.Param;
+import org.apache.catalina.User;
+import org.pofo.domain.rds.domain.project.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+    boolean existsByUserAndProject(User user, Project project);
+
+    Optional<Like> findByUserAndProject(User user, Project project);
+
+    @Query("SELECT l.project FROM Like l WHERE l.user = :user")
+    List<Project> findLikedProjectsByUser(@Param("user") User user);
+}

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/like/LikeRepository.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/like/LikeRepository.java
@@ -1,6 +1,6 @@
 package org.pofo.domain.rds.domain.like;
 
-import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.repository.query.Param;
 
 import jakarta.annotation.Nullable;
 import org.pofo.domain.rds.domain.project.Project;
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
     boolean existsByUserAndProject(User user, Project project);
@@ -17,6 +16,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     @Nullable
     Like findByUserAndProject(User user, Project project);
 
-    @Query("SELECT l.project FROM Like l WHERE l.user = :user")
-    List<Project> findLikedProjectsByUser(@Param("user") User user);
+    @Query("SELECT l.project FROM Like l WHERE l.user.id = :userId")
+    List<Project> findLikedProjectsByUserId(@Param("userId") Long userId);
 }

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/like/LikeRepository.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/like/LikeRepository.java
@@ -1,8 +1,10 @@
 package org.pofo.domain.rds.domain.like;
 
 import io.lettuce.core.dynamic.annotation.Param;
-import org.apache.catalina.User;
+
+import jakarta.annotation.Nullable;
 import org.pofo.domain.rds.domain.project.Project;
+import org.pofo.domain.rds.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -12,7 +14,8 @@ import java.util.Optional;
 public interface LikeRepository extends JpaRepository<Like, Long> {
     boolean existsByUserAndProject(User user, Project project);
 
-    Optional<Like> findByUserAndProject(User user, Project project);
+    @Nullable
+    Like findByUserAndProject(User user, Project project);
 
     @Query("SELECT l.project FROM Like l WHERE l.user = :user")
     List<Project> findLikedProjectsByUser(@Param("user") User user);

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/Project.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/Project.java
@@ -118,4 +118,14 @@ public class Project {
         }
         return this;
     }
+
+    public void increaseLikes() {
+        this.likes++;
+    }
+
+    public void decreaseLikes() {
+        if (this.likes > 0) {
+            this.likes--;
+        }
+    }
 }

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/Project.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/Project.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class Project {
 
     @Version
-    private Integer version;
+    private Integer version = 0;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/Project.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/Project.java
@@ -17,6 +17,9 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Project {
 
+    @Version
+    private Integer version;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -66,9 +69,9 @@ public class Project {
 
     public void addStack(Stack stack) {
         ProjectStack projectStack = ProjectStack.builder()
-                .project(this)
-                .stack(stack)
-                .build();
+            .project(this)
+            .stack(stack)
+            .build();
         this.stacks.add(projectStack);
     }
 
@@ -81,9 +84,9 @@ public class Project {
 
     public void addCategory(Category category) {
         ProjectCategory projectCategory = ProjectCategory.builder()
-                .project(this)
-                .category(category)
-                .build();
+            .project(this)
+            .category(category)
+            .build();
         this.categories.add(projectCategory);
     }
 

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/repository/ProjectRepository.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/repository/ProjectRepository.java
@@ -1,12 +1,14 @@
 package org.pofo.domain.rds.domain.project.repository;
 
+
 import jakarta.annotation.Nullable;
 import org.pofo.domain.rds.domain.project.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProjectRepository extends JpaRepository<Project, Long>, ProjectCustomRepository {
     @Nullable
     @Query("SELECT p FROM Project p LEFT JOIN FETCH p.stacks WHERE p.id = :id")
-    Project findById(long id);
+    Project findById(@Param("id") long id);
 }

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/repository/ProjectRepository.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/repository/ProjectRepository.java
@@ -2,12 +2,15 @@ package org.pofo.domain.rds.domain.project.repository;
 
 
 import jakarta.annotation.Nullable;
+import jakarta.persistence.LockModeType;
 import org.pofo.domain.rds.domain.project.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ProjectRepository extends JpaRepository<Project, Long>, ProjectCustomRepository {
+    @Lock(LockModeType.OPTIMISTIC)
     @Nullable
     @Query("SELECT p FROM Project p LEFT JOIN FETCH p.stacks WHERE p.id = :id")
     Project findById(@Param("id") long id);

--- a/pofo-domain/src/main/resources/application-db.yml
+++ b/pofo-domain/src/main/resources/application-db.yml
@@ -1,74 +1,76 @@
 spring:
-  jpa:
-    open-in-view: false
-    properties:
-      hibernate.default_batch_fetch_size: 100
+    jpa:
+        open-in-view: false
+        properties:
+            hibernate.default_batch_fetch_size: 100
 
-  data:
-    redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
-
----
-
-spring:
-  config:
-    activate:
-      on-profile: local
-
-  jpa:
-    hibernate:
-      ddl-auto: create-drop
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
-
-  datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:pofoTestDB?MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH
-    username: sa
-
-  h2:
-    console:
-      enabled: true
+    data:
+        redis:
+            host: ${REDIS_HOST:localhost}
+            port: ${REDIS_PORT:6379}
 
 ---
 
 spring:
-  config:
-    activate:
-      on-profile: dev
+    config:
+        activate:
+            on-profile: local
 
-  jpa:
-    hibernate:
-      ddl-auto: update
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
+    jpa:
+        hibernate:
+            ddl-auto: create-drop
+        properties:
+            hibernate:
+                show_sql: true
+                format_sql: true
+                connection:
+                    isolation: 2
 
-  datasource:
-    driver-class-name: org.postgresql.Driver
-    url: ${POSTGRES_DATASOURCE_URL}
-    username: ${POSTGRES_DATASOURCE_USERNAME}
-    password: ${POSTGRES_DATASOURCE_PASSWORD}
+    datasource:
+        driver-class-name: org.h2.Driver
+        url: jdbc:h2:mem:pofoTestDB?MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH
+        username: sa
+
+    h2:
+        console:
+            enabled: true
 
 ---
 
 spring:
-  config:
-    activate:
-      on-profile: prod
+    config:
+        activate:
+            on-profile: dev
 
-  jpa:
-    hibernate:
-      ddl-auto: none
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
+    jpa:
+        hibernate:
+            ddl-auto: update
+        properties:
+            hibernate:
+                dialect: org.hibernate.dialect.PostgreSQLDialect
 
-  datasource:
-    driver-class-name: org.postgresql.Driver
-    url: ${POSTGRES_DATASOURCE_URL}
-    username: ${POSTGRES_DATASOURCE_USERNAME}
-    password: ${POSTGRES_DATASOURCE_PASSWORD}
+    datasource:
+        driver-class-name: org.postgresql.Driver
+        url: ${POSTGRES_DATASOURCE_URL}
+        username: ${POSTGRES_DATASOURCE_USERNAME}
+        password: ${POSTGRES_DATASOURCE_PASSWORD}
+
+---
+
+spring:
+    config:
+        activate:
+            on-profile: prod
+
+    jpa:
+        hibernate:
+            ddl-auto: none
+        properties:
+            hibernate:
+                dialect: org.hibernate.dialect.PostgreSQLDialect
+
+    datasource:
+        driver-class-name: org.postgresql.Driver
+        url: ${POSTGRES_DATASOURCE_URL}
+        username: ${POSTGRES_DATASOURCE_USERNAME}
+        password: ${POSTGRES_DATASOURCE_PASSWORD}


### PR DESCRIPTION
## Overview

좋아요 기능 구현

### Related Issue
Issue Number : resolve #79 

## Task Details

프로젝트에 좋아요 기능을 추가했습니다.
likes 테이블을 따로 만들어서 좋아요 여부를 기록해둡니다.

또한, 페이지네이션에서 좋아요 개수가 표시될텐데, 매번 like 테이블에서 Count 집계 쿼리를 날려 조회하면 성능적 결함이 발생하므로 따로 Project에 좋아요 개수를 기록하는 칼럼을 만들어서 여기에서 받아오도록 처리했습니다.

이때, 이 부분은 동시성 문제가 발생하기 좋은 부분이라고 생각했습니다. 그런데 이를 비관적락, Redis 분산락 등의 방법으로 처리하면 너무 성능적으로 좋지 않습니다. (동시성이 발생하긴 하지만, 자주 발생하는 부분은 아니기 때문이라고 생각했습니다)

따라서, 낙관적락을 도입해서 Version 충돌시에만 다시 시도하도록 구성한 것입니다. 이에 따른 retry 로직도 작성했습니다. 5번 retry해서 실패하면 그냥 좋아요 실패했다고 오류를 띄워줍니다. (Errorcode like-003)

이에 따른 테스트 코드 작성도 했습니다. 스레드들이 동시에 좋아요를 증가시켜 테스트하는 방식입니다.

============= 추가=============

낙관적락 재시도가 정상적으로 작동하지 않아 Spring에서 제공하는 Retryable 라이브러리를 활용하도록 수정했습니다. 재시도 횟수는 10회이며, 지수 백오프 전략으로 대기 시작이 증가하도록 구성했습니다. 10회 실패시 그냥 좋아요가 실패합니다.

## Review Requirements

프로젝트 목록에서 바로 좋아요 할 수 있게 할 것인지, 또한 프로젝트 목록에서 자신의 좋아요 여부를 표시해야되는지 고민해볼 필요가 있습니다.

제가 감기에 걸려서 어제 하루종일 누워 있었고, 담주 홍콩으로 해외 출장 또 가는데 이에 관해서 일정 짜기 및 항공권/교통/숙소 등 예약을 제가 담당하게 되어 처리할게 많아 너무 바빠가지고 개발 속도가 느린점 정말 죄송하게 생각합니다... 최대한 열심히 해보겠습니다. 
