### PR TITLE
refactor: stack을 rds로 이전

### DIFF
--- a/pofo-api/build.gradle.kts
+++ b/pofo-api/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-graphql")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("io.github.oshai:kotlin-logging-jvm:7.0.0")
@@ -19,6 +20,8 @@ dependencies {
     testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
     testImplementation("io.kotest:kotest-assertions-core:5.9.1")
     testImplementation("io.kotest.extensions:kotest-extensions-spring:1.3.0")
+    testImplementation("io.mockk:mockk:1.13.14")
+    testImplementation("com.ninja-squad:springmockk:4.0.2")
 
     implementation("org.opensearch.client:opensearch-java:2.11.1")
 

--- a/pofo-api/src/main/kotlin/org/pofo/api/common/exception/handler/ApiExceptionHandler.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/common/exception/handler/ApiExceptionHandler.kt
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType
 import org.springframework.security.core.AuthenticationException
 import org.springframework.web.HttpMediaTypeNotSupportedException
 import org.springframework.web.HttpRequestMethodNotSupportedException
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -21,7 +22,7 @@ private val logger = KotlinLogging.logger {}
 /**
  * 서블릿 내의 에러를 감지합니다.
  * 필터 단에서 검출하는 인증 및 인가 에러는 security 부분을 참고해주세요
- * @see org.pofo.api.security.exception.handler
+ * @see org.pofo.api.domain.security.exception.handler
  */
 @RestControllerAdvice
 class ApiExceptionHandler {
@@ -82,6 +83,16 @@ class ApiExceptionHandler {
     fun handleHttpRequestMethodNotSupportedException(
         exception: HttpRequestMethodNotSupportedException,
     ): ApiResponse<Nothing> = ApiResponse.failure(ErrorCode.METHOD_NOT_ALLOWED)
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleMethodArgumentNotValidException(exception: MethodArgumentNotValidException): ApiResponse<Nothing> {
+        val bindingErrors = exception.bindingResult.allErrors
+        logger.info {
+            "binding errors: ${bindingErrors.joinToString("\n")}"
+        }
+        return ApiResponse.failure(ErrorCode.METHOD_ARGUMENT_NOT_VALID)
+    }
 
     /**
      * 처리되지 않은 오류를 검출합니다.

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeService.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/like/LikeService.kt
@@ -23,7 +23,7 @@ class LikeService(
     @Retryable(
         value = [OptimisticLockingFailureException::class, StaleObjectStateException::class],
         maxAttempts = 10,
-        backoff = Backoff(delay = 50, multiplier = 2.0),
+        backoff = Backoff(delay = 50, multiplier = 1.2),
     )
     @Transactional
     fun likeProject(
@@ -86,7 +86,7 @@ class LikeService(
     private fun <T> retryOptimisticLock(action: () -> T): T {
         var attempts = 0
         val maxRetries = 10
-        var waitTime = 50L
+        val waitTime = 50L
         while (true) {
             try {
                 return action()

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/security/SecurityConfig.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/security/SecurityConfig.kt
@@ -64,7 +64,12 @@ class SecurityConfig(
                     .forEach {
                         authorize(HttpMethod.POST, it, permitAll)
                     }
-                authorize(Version.V1 + "/tech-stack/**", permitAll)
+                authorize(Version.V1 + "/tech-stack/autocomplete", permitAll)
+                listOf("/tech-stack", "/tech-stack/upload-csv")
+                    .map { "${Version.V1}$it" }
+                    .forEach {
+                        authorize(HttpMethod.POST, it, hasRole("ADMIN"))
+                    }
                 authorize(anyRequest, authenticated)
             }
             exceptionHandling {

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/security/exception/handler/CommonAccessDeniedHandler.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/security/exception/handler/CommonAccessDeniedHandler.kt
@@ -18,11 +18,11 @@ class CommonAccessDeniedHandler : AccessDeniedHandler {
         response: HttpServletResponse,
         accessDeniedException: AccessDeniedException,
     ) {
-        response.status = HttpStatus.UNAUTHORIZED.value()
+        response.status = HttpStatus.FORBIDDEN.value()
         response.contentType = MediaType.APPLICATION_JSON_VALUE
         objectMapper.writeValue(
             response.writer,
-            ApiResponse.failure(ErrorCode.UNAUTHORIZED),
+            ApiResponse.failure(ErrorCode.FORBIDDEN),
         )
     }
 }

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/stack/StackApiDocs.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/stack/StackApiDocs.kt
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.pofo.api.common.response.ApiResponse
-import org.pofo.infra.elasticsearch.document.TechStackAutoComplete
+import org.pofo.api.domain.stack.dto.StackInsertRequest
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.multipart.MultipartFile
@@ -22,7 +22,7 @@ interface StackApiDocs {
         value = [
             SwaggerResponse(
                 responseCode = "200",
-                description = "기술스택 삽입 성공",
+                description = "단일 기술 스택 삽입 성공 시",
                 content = [
                     Content(
                         mediaType = "application/json",
@@ -32,7 +32,6 @@ interface StackApiDocs {
                                 value = """
                                     {
                                       "success": true,
-                                      "data": "성공하셨습니다"
                                     }
                                 """,
                             ),
@@ -42,16 +41,16 @@ interface StackApiDocs {
             ),
         ],
     )
-    fun insertTechStack(
-        @RequestBody techStack: TechStackAutoComplete,
-    ): ApiResponse<String>
+    fun insertStack(
+        @RequestBody stack: StackInsertRequest,
+    ): ApiResponse<*>
 
     @Operation(summary = "CSV 파일 업로드", description = "CSV 파일의 기술 스택 데이터를 Bulk로 OpenSearch에 대량 삽입합니다.")
     @ApiResponses(
         value = [
             SwaggerResponse(
                 responseCode = "200",
-                description = "Batch로 기술 스택 삽입 성공",
+                description = "CSV로 기술 스택 삽입 성공 시",
                 content = [
                     Content(
                         mediaType = "application/json",
@@ -61,7 +60,6 @@ interface StackApiDocs {
                                 value = """
                                     {
                                       "success": true,
-                                      "data": "성공하셨습니다"
                                     }
                                 """,
                             ),
@@ -76,7 +74,7 @@ interface StackApiDocs {
     )
     fun uploadCSV(
         @RequestParam("file") file: MultipartFile,
-    ): ApiResponse<String>
+    ): ApiResponse<*>
 
     @Operation(summary = "자동완성 검색", description = "사용자가 입력한 키워드에 기반하여 자동완성 제안을 제공합니다.")
     @ApiResponses(
@@ -94,7 +92,7 @@ interface StackApiDocs {
                                     {
                                       "success": true,
                                       "data":
-                                        "autocompelte" : [
+                                        "autocomplete" : [
                                            "Spring", "Spring Batch", "Spring Cloud Gateway"
                                         ]
                                     }
@@ -106,7 +104,7 @@ interface StackApiDocs {
                                     {
                                       "success": true,
                                       "data":
-                                        "autocompelte" : [
+                                        "autocomplete" : [
                                             "AWS EC2", "AWS RDS", "AWS SQS", "AWS Snowball", "AWS Redshift"
                                         ]
                                     }
@@ -123,61 +121,5 @@ interface StackApiDocs {
     )
     fun autoComplete(
         @RequestParam("query") query: String,
-    ): ApiResponse<Map<String, List<String>>>
-
-    @Operation(summary = "단일 필드 검색", description = "특정 필드와 키워드로 기술 스택 데이터를 검색합니다.")
-    @ApiResponses(
-        value = [
-            SwaggerResponse(
-                responseCode = "200",
-                description = "회원가입 성공",
-                content = [
-                    Content(
-                        mediaType = "application/json",
-                        examples = [
-                            ExampleObject(
-                                name = "단일 기술 스택 검색",
-                                value = """
-                                    {
-                                      "success": true,
-                                      "data":  "data": [
-                                        {
-                                          "id": "string",
-                                          "suggest": {
-                                            "input": [
-                                              "string"
-                                            ],
-                                            "contexts": {
-                                              "additionalProp1": [
-                                                "string"
-                                              ],
-                                              "additionalProp2": [
-                                                "string"
-                                              ],
-                                              "additionalProp3": [
-                                                "string"
-                                              ]
-                                            },
-                                            "weight": 0
-                                          },
-                                          "name": "string"
-                                        }
-                                      ]
-                                    }
-                                """,
-                            ),
-                        ],
-                    ),
-                ],
-            ),
-        ],
-    )
-    @Parameters(
-        Parameter(name = "field", description = "검색할 필드명", required = true, `in` = ParameterIn.QUERY),
-        Parameter(name = "keyword", description = "검색 키워드", required = true, `in` = ParameterIn.QUERY),
-    )
-    fun searchSingleField(
-        @RequestParam("field") field: String,
-        @RequestParam("keyword") keyword: String,
-    ): ApiResponse<List<TechStackAutoComplete>>
+    ): ApiResponse<List<String>>
 }

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/stack/StackApiDocs.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/stack/StackApiDocs.kt
@@ -16,7 +16,7 @@ import org.springframework.web.multipart.MultipartFile
 import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerResponse
 
 @Tag(name = "[Tech Stack API]", description = "기술 스택 관련 API")
-interface AutocompleteApiDocs {
+interface StackApiDocs {
     @Operation(summary = "단일 기술 스택 삽입", description = "단일 기술 스택 데이터를 OpenSearch에 삽입합니다.")
     @ApiResponses(
         value = [

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/stack/StackController.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/stack/StackController.kt
@@ -15,16 +15,16 @@ import org.springframework.web.multipart.MultipartFile
     Version.V1 +
         "/tech-stack",
 )
-class AutocompleteController(
-    private val openSearchService: OpenSearchService,
-) : AutocompleteApiDocs {
+class StackController(
+    private val stackService: StackService,
+) : StackApiDocs {
     @PostMapping(
         "/",
     )
     override fun insertTechStack(
         @RequestBody techStack: TechStackAutoComplete,
     ): ApiResponse<String> {
-        openSearchService
+        stackService
             .indexTechStack(
                 techStack,
             )
@@ -42,7 +42,7 @@ class AutocompleteController(
             "file",
         ) file: MultipartFile,
     ): ApiResponse<String> {
-        openSearchService
+        stackService
             .bulkInsertFromCSV(
                 file,
             )
@@ -59,7 +59,7 @@ class AutocompleteController(
         @RequestParam query: String,
     ): ApiResponse<Map<String, List<String>>> {
         val suggestions =
-            openSearchService
+            stackService
                 .getSuggestions(
                     query,
                 )
@@ -86,7 +86,7 @@ class AutocompleteController(
     ): ApiResponse<List<TechStackAutoComplete>> =
         ApiResponse
             .success(
-                openSearchService
+                stackService
                     .searchSingleField(
                         field,
                         keyword,

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/stack/StackController.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/stack/StackController.kt
@@ -1,95 +1,48 @@
-@file:Suppress(
-    "ktlint:standard:no-wildcard-imports",
-)
-
 package org.pofo.api.domain.stack
 
+import jakarta.validation.Valid
 import org.pofo.api.common.response.ApiResponse
+import org.pofo.api.domain.stack.dto.StackInsertRequest
 import org.pofo.common.response.Version
-import org.pofo.infra.elasticsearch.document.TechStackAutoComplete
-import org.springframework.web.bind.annotation.*
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 
 @RestController
-@RequestMapping(
-    Version.V1 +
-        "/tech-stack",
-)
+@RequestMapping(Version.V1 + "/tech-stack")
 class StackController(
     private val stackService: StackService,
 ) : StackApiDocs {
-    @PostMapping(
-        "/",
-    )
-    override fun insertTechStack(
-        @RequestBody techStack: TechStackAutoComplete,
+    @PostMapping("")
+    @ResponseStatus(HttpStatus.CREATED)
+    override fun insertStack(
+        @RequestBody @Valid stack: StackInsertRequest,
     ): ApiResponse<String> {
-        stackService
-            .indexTechStack(
-                techStack,
-            )
-        return ApiResponse
-            .success(
-                "단일 데이터 삽입 성공",
-            )
+        stackService.insertStack(stack)
+        return ApiResponse.success("단일 데이터 삽입 성공")
     }
 
-    @PostMapping(
-        "/upload-csv",
-    )
+    @PostMapping("/upload-csv")
+    @ResponseStatus(HttpStatus.CREATED)
     override fun uploadCSV(
-        @RequestParam(
-            "file",
-        ) file: MultipartFile,
+        @RequestParam("file") file: MultipartFile,
     ): ApiResponse<String> {
-        stackService
-            .bulkInsertFromCSV(
-                file,
-            )
+        val successCount = stackService.bulkInsertFromCSV(file)
         return ApiResponse
-            .success(
-                "CSV 데이터 삽입 성공",
-            )
+            .success("${successCount}개의 CSV 데이터 삽입 성공")
     }
 
-    @GetMapping(
-        "/autocomplete",
-    )
+    @GetMapping("/autocomplete")
     override fun autoComplete(
         @RequestParam query: String,
-    ): ApiResponse<Map<String, List<String>>> {
-        val suggestions =
-            stackService
-                .getSuggestions(
-                    query,
-                )
-        val responseData =
-            mapOf(
-                "autocomplete" to
-                    suggestions,
-            )
-        return ApiResponse
-            .success(
-                responseData,
-            )
+    ): ApiResponse<List<String>> {
+        val suggestions = stackService.getSuggestions(query)
+        return ApiResponse.success(suggestions)
     }
-
-    @Deprecated(
-        message = "제거될 예정인 API 입니다",
-    )
-    @GetMapping(
-        "/field",
-    )
-    override fun searchSingleField(
-        @RequestParam field: String,
-        @RequestParam keyword: String,
-    ): ApiResponse<List<TechStackAutoComplete>> =
-        ApiResponse
-            .success(
-                stackService
-                    .searchSingleField(
-                        field,
-                        keyword,
-                    ),
-            )
 }

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/stack/StackService.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/stack/StackService.kt
@@ -19,7 +19,7 @@ import org.springframework.web.multipart.MultipartFile
 import java.io.InputStreamReader
 
 @Service
-class OpenSearchService(
+class StackService(
     private val openSearchClient: OpenSearchClient,
 ) {
     fun bulkInsertFromCSV(file: MultipartFile) {

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/stack/StackService.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/stack/StackService.kt
@@ -1,315 +1,78 @@
 package org.pofo.api.domain.stack
 
 import com.opencsv.CSVReader
-import org.opensearch.client.opensearch.OpenSearchClient
-import org.opensearch.client.opensearch._types.FieldValue
-import org.opensearch.client.opensearch.core.BulkRequest
-import org.opensearch.client.opensearch.core.IndexRequest
-import org.opensearch.client.opensearch.core.IndexResponse
-import org.opensearch.client.opensearch.core.SearchRequest
-import org.opensearch.client.opensearch.core.SearchResponse
-import org.opensearch.client.opensearch.core.bulk.CreateOperation
-import org.opensearch.client.opensearch.core.search.FieldSuggester
-import org.opensearch.client.opensearch.core.search.SourceConfig
-import org.opensearch.client.opensearch.core.search.Suggester
-import org.pofo.infra.elasticsearch.document.TechStackAutoComplete
-import org.springframework.data.elasticsearch.core.suggest.Completion
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.pofo.api.domain.stack.dto.StackInsertRequest
+import org.pofo.domain.rds.domain.project.Stack
+import org.pofo.domain.rds.domain.project.repository.StackRepository
+import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 import java.io.InputStreamReader
 
 @Service
+@Primary
 class StackService(
-    private val openSearchClient: OpenSearchClient,
+    private val stackRepository: StackRepository,
 ) {
-    fun bulkInsertFromCSV(file: MultipartFile) {
-        val indexName =
-            "stack-auto-complete"
+    companion object {
+        val logger = KotlinLogging.logger {}
+    }
 
-        val bulkRequest =
-            BulkRequest
-                .Builder()
-        CSVReader(
-            InputStreamReader(
-                file.inputStream,
-            ),
-        ).use { csvReader ->
-            val rows =
-                csvReader
-                    .readAll()
-                    .drop(
-                        1,
-                    )
+    @Transactional
+    fun insertStack(stackInsertRequest: StackInsertRequest) {
+        val stack =
+            Stack
+                .builder()
+                .name(stackInsertRequest.name)
+                .imageUrl(stackInsertRequest.imageUrl)
+                .build()
 
-            rows
-                .forEach { row ->
-                    val stackName =
-                        row[0]
-                    val docId =
-                        stackName
-                            .replace(
-                                " ",
-                                "_",
-                            ).lowercase()
+        stackRepository.save(stack)
+    }
 
-                    val suggestInputs =
-                        generateAllCombinations(
-                            stackName,
-                        )
+    fun bulkInsertFromCSV(file: MultipartFile): Int {
+        var successCount = 0
+        var failedCount = 0
 
-                    val techStack =
-                        TechStackAutoComplete
+        file.inputStream.use { inputStream ->
+            CSVReader(InputStreamReader(inputStream)).use { reader ->
+                val rows =
+                    reader
+                        .readAll()
+                        .drop(1)
+
+                rows.forEach { row ->
+                    val stackName = row[0]
+                    val stackImageUrl = row[2]
+
+                    val stack =
+                        Stack
                             .builder()
-                            .id(
-                                docId,
-                            ).suggest(
-                                Completion(
-                                    suggestInputs,
-                                ),
-                            ).name(
-                                stackName,
-                            ).build()
+                            .name(stackName)
+                            .imageUrl(stackImageUrl)
+                            .build()
 
-                    bulkRequest
-                        .operations { operation ->
-                            operation
-                                .create { co: CreateOperation.Builder<TechStackAutoComplete> ->
-                                    co
-                                        .index(
-                                            indexName,
-                                        ).id(
-                                            docId,
-                                        ).document(
-                                            techStack,
-                                        )
-                                }
-                        }
+                    runCatching {
+                        stackRepository.save(stack)
+                    }.onSuccess {
+                        successCount++
+                    }.onFailure {
+                        failedCount++
+                        logger.warn { "Failed to insert stack $stackName" }
+                    }
                 }
-        }
-
-        openSearchClient
-            .bulk(
-                bulkRequest
-                    .build(),
-            )
-    }
-
-    private fun generateAllCombinations(input: String): List<String> {
-        val cleanedInput =
-            input
-                .replace(
-                    Regex(
-                        "[^A-Za-z0-9 ]",
-                    ),
-                    "",
-                )
-        val words =
-            cleanedInput
-                .split(
-                    " ",
-                )
-        val combinations =
-            mutableSetOf<String>()
-
-        for (i in words.indices) {
-            for (j in i until
-                words.size) {
-                combinations
-                    .add(
-                        words
-                            .slice(
-                                i..j,
-                            ).joinToString(
-                                " ",
-                            ).lowercase(),
-                    )
             }
         }
 
-        return combinations
-            .toList()
+        logger.info { "bulkInsertFromCSV - success: $successCount / failed: $failedCount" }
+        return successCount
     }
 
+    @Transactional(readOnly = true)
     fun getSuggestions(query: String): List<String> {
-        val indexName =
-            "stack-auto-complete"
-        val sanitizedQuery =
-            query
-                .lowercase()
-                .replace(
-                    " ",
-                    "",
-                )
-
-        return try {
-            val map =
-                HashMap<String, FieldSuggester>()
-            map["tech-suggestion"] =
-                FieldSuggester.of { fs ->
-                    fs
-                        .completion { cs ->
-                            cs
-                                .skipDuplicates(
-                                    true,
-                                ).size(
-                                    20,
-                                ).field(
-                                    "suggest",
-                                )
-                        }
-                }
-
-            val suggester =
-                Suggester
-                    .of { s ->
-                        s
-                            .suggesters(
-                                map,
-                            ).text(
-                                sanitizedQuery,
-                            )
-                    }
-
-            val searchRequest =
-                SearchRequest
-                    .of { search ->
-                        search
-                            .index(
-                                indexName,
-                            ).suggest(
-                                suggester,
-                            ).source(
-                                SourceConfig
-                                    .of { s ->
-                                        s
-                                            .filter { f ->
-                                                f
-                                                    .includes(
-                                                        listOf(
-                                                            "name",
-                                                        ),
-                                                    )
-                                            }
-                                    },
-                            )
-                    }
-
-            val response =
-                openSearchClient
-                    .search(
-                        searchRequest,
-                        TechStackAutoComplete::class.java,
-                    )
-
-            response.suggest()["tech-suggestion"]?.flatMap { suggestion ->
-                suggestion
-                    .completion()
-                    .options()
-                    .map {
-                        it
-                            .source()
-                            .name
-                    }
-            }
-                ?: emptyList()
-        } catch (
-            e: Exception,
-        ) {
-            e
-                .printStackTrace()
-            emptyList()
-        }
+        val fountStacks = stackRepository.findByNameContainingIgnoreCase(query)
+        return fountStacks.map { it.name }
     }
-
-    fun indexTechStack(techStack: TechStackAutoComplete): Boolean {
-        val indexName =
-            "stack-auto-complete"
-        return try {
-            val request =
-                IndexRequest
-                    .Builder<TechStackAutoComplete>()
-                    .index(
-                        indexName,
-                    ).id(
-                        techStack.id,
-                    ).document(
-                        techStack,
-                    ).build()
-
-            val response:
-                IndexResponse =
-                openSearchClient
-                    .index(
-                        request,
-                    )
-            response.result().name ==
-                "created"
-        } catch (
-            e: Exception,
-        ) {
-            System.out
-                .println(
-                    e,
-                )
-            e
-                .printStackTrace()
-            false
-        }
-    }
-
-    fun searchSingleField(
-        fieldName: String,
-        keyword: String,
-    ): List<TechStackAutoComplete> =
-        try {
-            val indexName =
-                "stack-auto-complete"
-
-            val request =
-                SearchRequest
-                    .of { searchRequest ->
-                        searchRequest
-                            .index(
-                                indexName,
-                            ).query { query ->
-                                query
-                                    .match { matchQuery ->
-                                        matchQuery
-                                            .field(
-                                                fieldName,
-                                            )
-                                        matchQuery
-                                            .query(
-                                                FieldValue
-                                                    .of(
-                                                        keyword,
-                                                    ),
-                                            )
-                                        matchQuery
-                                    }
-                            }
-                    }
-
-            val response:
-                SearchResponse<TechStackAutoComplete> =
-                openSearchClient
-                    .search(
-                        request,
-                        TechStackAutoComplete::class.java,
-                    )
-
-            response
-                .hits()
-                .hits()
-                .mapNotNull {
-                    it
-                        .source()
-                }
-        } catch (
-            e: Exception,
-        ) {
-            e
-                .printStackTrace()
-            emptyList()
-        }
 }

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/stack/dto/StackInsertRequest.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/stack/dto/StackInsertRequest.kt
@@ -1,0 +1,14 @@
+package org.pofo.api.domain.stack.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+
+data class StackInsertRequest(
+    @field:NotBlank(message = "스택 이름은 필수 입력 값입니다.")
+    val name: String,
+    @field:Pattern(
+        regexp = "^https://[\\w\\-]+(\\.[\\w\\-]+)+([/#?].*)?$",
+        message = "스택 이미지는 URL 형식이여야 하며, HTTPS 프로토콜을 사용해야합니다.",
+    )
+    val imageUrl: String?,
+)

--- a/pofo-api/src/test/kotlin/org/pofo/api/common/config/KotestConfig.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/common/config/KotestConfig.kt
@@ -1,0 +1,18 @@
+package org.pofo.api.common.config
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
+import io.kotest.core.spec.IsolationMode
+import io.kotest.extensions.spring.SpringAutowireConstructorExtension
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
+
+class KotestConfig : AbstractProjectConfig() {
+    override val parallelism = 3
+
+    override fun extensions(): List<Extension> =
+        listOf(SpringTestExtension(SpringTestLifecycleMode.Root), SpringAutowireConstructorExtension)
+
+    override val isolationMode: IsolationMode
+        get() = IsolationMode.InstancePerLeaf
+}

--- a/pofo-api/src/test/kotlin/org/pofo/api/common/fixture/ProjectFixture.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/common/fixture/ProjectFixture.kt
@@ -1,4 +1,4 @@
-package org.pofo.api.fixture
+package org.pofo.api.common.fixture
 
 import org.pofo.domain.rds.domain.project.Project
 

--- a/pofo-api/src/test/kotlin/org/pofo/api/common/fixture/StackFixture.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/common/fixture/StackFixture.kt
@@ -1,0 +1,31 @@
+package org.pofo.api.common.fixture
+
+import org.pofo.domain.rds.domain.project.Stack
+import org.springframework.mock.web.MockMultipartFile
+
+class StackFixture {
+    companion object {
+        val DEFAULT_STACK_LIST: List<Stack> =
+            listOf(
+                Stack(1, "JavaScript", "https://img.stackshare.io/service/1209/javascript.jpeg"),
+                Stack(2, "Python", "https://img.stackshare.io/service/993/pUBY5pVj.png"),
+                Stack(3, "Node.js", "https://img.stackshare.io/service/1011/n1JRsFeB_400x400.png"),
+            )
+
+        fun createMockMultipartFile(stackList: List<Stack> = DEFAULT_STACK_LIST): MockMultipartFile {
+            val stringBuilder = StringBuilder()
+            stringBuilder.append("stack_name,stack_type,image_url,homepage_url\n")
+            stackList.forEach { stack ->
+                stringBuilder.append("${stack.name},_,${stack.imageUrl},_\n")
+            }
+            return MockMultipartFile(
+                "file",
+                "stack.csv",
+                "text/csv",
+                (
+                    stringBuilder.toString()
+                ).toByteArray(),
+            )
+        }
+    }
+}

--- a/pofo-api/src/test/kotlin/org/pofo/api/common/fixture/UserFixture.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/common/fixture/UserFixture.kt
@@ -1,4 +1,4 @@
-package org.pofo.api.fixture
+package org.pofo.api.common.fixture
 
 import org.pofo.domain.rds.domain.user.User
 import org.pofo.domain.rds.domain.user.UserRole
@@ -10,7 +10,7 @@ class UserFixture {
         private const val TEST_USERNAME = "testUsername"
 
         fun createUser(): User =
-            this.createUser(
+            createUser(
                 email = TEST_USER_EMAIL,
                 password = TEST_USER_PASSWORD,
                 username = TEST_USERNAME,
@@ -18,7 +18,7 @@ class UserFixture {
             )
 
         fun createUser(role: UserRole): User =
-            this.createUser(
+            createUser(
                 email = TEST_USER_EMAIL,
                 password = TEST_USER_PASSWORD,
                 username = TEST_USERNAME,
@@ -33,6 +33,7 @@ class UserFixture {
         ): User =
             User
                 .builder()
+                .id(1L)
                 .email(email)
                 .password(password)
                 .username(username)

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/project/ProjectControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/project/ProjectControllerTest.kt
@@ -3,6 +3,8 @@ package org.pofo.api.domain.project
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.pofo.api.common.fixture.ProjectFixture.Companion.createProject
+import org.pofo.api.common.fixture.UserFixture
 import org.pofo.api.domain.project.dto.ProjectCreateRequest
 import org.pofo.api.domain.project.dto.ProjectResponse
 import org.pofo.api.domain.project.dto.ProjectUpdateRequest
@@ -10,8 +12,6 @@ import org.pofo.api.domain.security.jwt.JwtService
 import org.pofo.api.domain.security.jwt.JwtTokenData
 import org.pofo.api.domain.user.UserService
 import org.pofo.api.domain.user.dto.UserRegisterRequest
-import org.pofo.api.fixture.ProjectFixture.Companion.createProject
-import org.pofo.api.fixture.UserFixture
 import org.pofo.domain.rds.domain.project.Project
 import org.pofo.domain.rds.domain.user.User
 import org.springframework.beans.factory.annotation.Autowired

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/stack/StackControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/stack/StackControllerTest.kt
@@ -1,0 +1,160 @@
+package org.pofo.api.domain.stack
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.called
+import io.mockk.every
+import io.mockk.just
+import io.mockk.runs
+import io.mockk.verify
+import org.pofo.api.common.fixture.StackFixture
+import org.pofo.api.domain.security.jwt.JwtAuthenticationFilter
+import org.pofo.api.domain.stack.dto.StackInsertRequest
+import org.pofo.common.exception.ErrorCode
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.multipart
+import org.springframework.test.web.servlet.post
+
+@WebMvcTest(
+    controllers = [StackController::class],
+    excludeAutoConfiguration = [SecurityAutoConfiguration::class, OAuth2ClientAutoConfiguration::class],
+    excludeFilters = [
+        ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = [JwtAuthenticationFilter::class],
+        ),
+    ],
+)
+@ActiveProfiles("test")
+internal class StackControllerTest(
+    @Autowired val mockMvc: MockMvc,
+    @MockkBean val stackService: StackService,
+) : DescribeSpec({
+        val objectMapper = jacksonObjectMapper()
+
+        describe("POST /v1/tech-stack - 단일 스택 삽입 시") {
+            context("이름만 보내면") {
+                it("단일 스택 저장에 성공하고, status 201을 응답한다.") {
+                    val stackInsertRequest = StackInsertRequest(name = "Kotlin", imageUrl = null)
+
+                    every { stackService.insertStack(any(StackInsertRequest::class)) } just runs
+
+                    mockMvc
+                        .post("/v1/tech-stack") {
+                            contentType = MediaType.APPLICATION_JSON
+                            content = objectMapper.writeValueAsString(stackInsertRequest)
+                        }.andExpect {
+                            status { isCreated() }
+                            jsonPath("$.success") { value(true) }
+                        }
+                }
+            }
+
+            context("이름과 URL을 보내면") {
+                it("단일 스택 저장에 성공하고, status 200을 응답한다.") {
+                    val stackInsertRequest =
+                        StackInsertRequest(
+                            name = "Kotlin",
+                            imageUrl = "https://avatars.githubusercontent.com/u/102505374?v=4",
+                        )
+
+                    every { stackService.insertStack(any(StackInsertRequest::class)) } just runs
+
+                    mockMvc
+                        .post("/v1/tech-stack") {
+                            contentType = MediaType.APPLICATION_JSON
+                            content = objectMapper.writeValueAsString(stackInsertRequest)
+                        }.andExpect {
+                            status { isCreated() }
+                            jsonPath("$.success") { value(true) }
+                        }
+                }
+            }
+
+            context("이름이 없으면") {
+                it("단일 스택 저장에 실패하고, status 400을 응답한다.") {
+                    val stackInsertRequest = StackInsertRequest(name = "", imageUrl = null)
+
+                    verify { stackService wasNot called }
+
+                    mockMvc
+                        .post("/v1/tech-stack") {
+                            contentType = MediaType.APPLICATION_JSON
+                            content = objectMapper.writeValueAsString(stackInsertRequest)
+                        }.andExpect {
+                            status { isBadRequest() }
+                            jsonPath("$.success") { value(false) }
+                            jsonPath("$.code") { value(ErrorCode.METHOD_ARGUMENT_NOT_VALID.code) }
+                        }
+                }
+            }
+
+            context("URL 형식이 올바르지 않으면") {
+                it("단일 스택 저장에 실패하고, status 400을 응답한다.") {
+                    val stackInsertRequest = StackInsertRequest(name = "Kotlin", imageUrl = "data://image")
+
+                    verify { stackService wasNot called }
+
+                    mockMvc
+                        .post("/v1/tech-stack") {
+                            contentType = MediaType.APPLICATION_JSON
+                            content = objectMapper.writeValueAsString(stackInsertRequest)
+                        }.andExpect {
+                            status { isBadRequest() }
+                            jsonPath("$.success") { value(false) }
+                            jsonPath("$.code") { value(ErrorCode.METHOD_ARGUMENT_NOT_VALID.code) }
+                        }
+                }
+            }
+        }
+
+        describe("POST /tech-stack/upload-csv - CSV를 이용한 스택 삽입 시") {
+            context("form-data에 key를 file해서 stack.csv를 넣으면") {
+                it("CSV 스택 저장에 성공하고, status 201을 응답한다.") {
+                    val mockFile = StackFixture.createMockMultipartFile()
+
+                    every { stackService.bulkInsertFromCSV(any()) } returns 3
+
+                    mockMvc
+                        .multipart("/v1/tech-stack/upload-csv") {
+                            file(mockFile)
+                        }.andExpect {
+                            status { isCreated() }
+                            jsonPath("$.success") { value(true) }
+                        }
+                }
+            }
+        }
+
+        describe("GET /tech-stack/autocomplete - 스택 자동 완성 검색 시") {
+            context("String으로 된 쿼리를 보내면") {
+                it("status 200과 자동 완성 결과를 응답한다.") {
+                    val query = "Rea"
+                    val suggestions = listOf("React", "React Native", "PrimeReact")
+
+                    every { stackService.getSuggestions(query) } returns suggestions
+
+                    mockMvc
+                        .get("/v1/tech-stack/autocomplete") {
+                            param("query", query)
+                        }.andExpect {
+                            status { isOk() }
+                            jsonPath("$.success") { value(true) }
+                            jsonPath("$.data[0]") { value(suggestions[0]) }
+                            jsonPath("$.data[1]") { value(suggestions[1]) }
+                            jsonPath("$.data[2]") { value(suggestions[2]) }
+                        }
+                }
+            }
+        }
+    })

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/stack/StackControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/stack/StackControllerTest.kt
@@ -42,7 +42,7 @@ internal class StackControllerTest(
 ) : DescribeSpec({
         val objectMapper = jacksonObjectMapper()
 
-        describe("POST /v1/tech-stack - 단일 스택 삽입 시") {
+        describe("POST /tech-stack - 단일 스택 삽입 시") {
             context("이름만 보내면") {
                 it("단일 스택 저장에 성공하고, status 201을 응답한다.") {
                     val stackInsertRequest = StackInsertRequest(name = "Kotlin", imageUrl = null)

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/stack/StackServiceTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/stack/StackServiceTest.kt
@@ -1,0 +1,31 @@
+package org.pofo.api.domain.stack
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.pofo.api.common.fixture.StackFixture
+import org.pofo.domain.rds.domain.project.Stack
+import org.pofo.domain.rds.domain.project.repository.StackRepository
+
+class StackServiceTest :
+    StringSpec({
+        lateinit var stackService: StackService
+        lateinit var stackRepository: StackRepository
+
+        beforeEach {
+            stackRepository = mockk<StackRepository>()
+            stackService = StackService(stackRepository)
+        }
+
+        "bulkInsertFromCSV" {
+            val stackList = StackFixture.DEFAULT_STACK_LIST
+            val mockFile = StackFixture.createMockMultipartFile(stackList = stackList)
+
+            every { stackRepository.save(any(Stack::class)) } returnsMany stackList
+
+            val result = stackService.bulkInsertFromCSV(file = mockFile)
+
+            result shouldBe 3
+        }
+    })

--- a/pofo-common/src/main/kotlin/org/pofo/common/exception/ErrorCode.kt
+++ b/pofo-common/src/main/kotlin/org/pofo/common/exception/ErrorCode.kt
@@ -11,6 +11,7 @@ enum class ErrorCode(
     NOT_FOUND(404, "잘못된 URL 호출", "COMMON-004"),
     METHOD_NOT_ALLOWED(405, "허용되지 않는 메소드", "COMMON-005"),
     UNSUPPORTED_MEDIA_TYPE(415, "지원하지 않는 Content 형식", "COMMON-006"),
+    METHOD_ARGUMENT_NOT_VALID(400, "주어진 인자가 잘못되었습니다.", "COMMON-274"),
 
     // USER
     USER_NOT_FOUND(404, "유저를 찾을 수 없습니다.", "USER-001"),

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/Project.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/Project.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class Project {
 
     @Version
-    private Integer version = 0;
+    private Integer version;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/Stack.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/Stack.java
@@ -1,14 +1,16 @@
 package org.pofo.domain.rds.domain.project;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import javax.annotation.Nullable;
 
 @Entity
 @Table(name = "stack")
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Stack {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -17,10 +19,7 @@ public class Stack {
     @Column(unique = true, nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Column
+    @Nullable
     private String imageUrl;
-
-    public Stack(String name) {
-        this.name = name;
-    }
 }

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/Stack.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/Stack.java
@@ -14,8 +14,11 @@ public class Stack {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true)
+    @Column(unique = true, nullable = false)
     private String name;
+
+    @Column(nullable = false)
+    private String imageUrl;
 
     public Stack(String name) {
         this.name = name;

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/repository/StackRepository.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/repository/StackRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface StackRepository extends JpaRepository<Stack, Long> {
     List<Stack> findByNameIn(Collection<String> names);
+    List<Stack> findByNameContainingIgnoreCase(String name);
 }


### PR DESCRIPTION
## Overview

stack 검색 기능을 OpenSearch에서 RDS로 완전히 이전했습니다.

### Related Issue
Issue Number : resolves #88 

## Task Details

- DB상으론 LIKE문이 맞지만 JPA에서 containing으로 구현했습니다.
  - https://velog.io/@jehpark/Spring-Data-JPA-%EC%BF%BC%EB%A6%AC-like-containing%EC%9D%98-%EC%B0%A8%EC%9D%B4%EC%A0%90
- stack 관련 테스트를 단위 테스트로 구현해보았습니다.
- stack을 업로드하는 기능은 ADMIN만 가능하도록 처리했습니다. (DB 접근 필요)

이전에 테스트가 제대로 작동하지 않았던 오류는 아마 kotest의 isolation mode에 관련된 것 같아요.
https://velog.io/@glencode/Kotest%EC%9D%98-Lifecycle-Hook-IsolationMode
아마 다른 테스트의 조회가 병렬적으로 이뤄지면서 문제가 발생했을 가능성이 보입니다.

## Screenshots (Optional)

## Test Scope & Checklist (Optional)

- [ ] Test Task 1
- [ ] Test Task 2

## Review Requirements

stack 관련 테스트를 단위 테스트로 구현해보았는데 어떤지 한번 봐주시겠어요?
controller, service, repository를 구현했고, 단순히 저장, 조회같은 부분을 테스트하진 않았습니다.
테스트는 많이 짜볼수록 아는거라고 해서.. 같이 발전할 수 있는 기회였으면 좋겠습니다. 