### PR TITLE
feat: 프로젝트 유저 이름을 이용한 검색 기능 구현

### DIFF
--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/project/ProjectController.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/project/ProjectController.kt
@@ -26,6 +26,7 @@ class ProjectController(
                 projectId,
             )
 
+    @Deprecated(message = "요청 사항이 늘어남에 따라 검색 기능으로 대체", replaceWith = ReplaceWith("searchProject"))
     @QueryMapping
     fun getAllProjectsByPagination(
         @Argument cursor: Long?,

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/project/ProjectService.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/project/ProjectService.kt
@@ -74,7 +74,7 @@ class ProjectService(
             Project
                 .builder()
                 .title(projectCreateRequest.title)
-                .Bio(projectCreateRequest.bio)
+                .bio(projectCreateRequest.bio)
                 .urls(projectCreateRequest.urls)
                 .imageUrls(projectCreateRequest.imageUrls)
                 .keyImageIndex(keyImageIndex)
@@ -190,23 +190,20 @@ class ProjectService(
 
     fun searchProject(projectSearchRequest: ProjectSearchRequest): ProjectListResponse {
         val pageRequest =
-            PageRequest
-                .of(
-                    projectSearchRequest.page,
-                    projectSearchRequest.size,
-                )
+            PageRequest.of(
+                projectSearchRequest.page,
+                projectSearchRequest.size,
+            )
         val projectSlice =
             projectRepository
                 .searchProjectWithQuery(
                     projectSearchRequest.title,
                     projectSearchRequest.categories,
                     projectSearchRequest.stackNames,
+                    projectSearchRequest.authorName,
                     pageRequest,
                 )
-        return ProjectListResponse
-            .from(
-                projectSlice,
-            )
+        return ProjectListResponse.from(projectSlice)
     }
 
     private fun logNotExistStacks(

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/project/dto/ProjectResponse.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/project/dto/ProjectResponse.kt
@@ -36,7 +36,7 @@ data class ProjectResponse(
                     .map {
                         it.stack.name
                     },
-                project.author.email,
+                project.author.username,
             )
     }
 }

--- a/pofo-api/src/main/kotlin/org/pofo/api/domain/project/dto/ProjectSearchRequest.kt
+++ b/pofo-api/src/main/kotlin/org/pofo/api/domain/project/dto/ProjectSearchRequest.kt
@@ -6,6 +6,7 @@ data class ProjectSearchRequest(
     val title: String?,
     val categories: List<Category>?,
     val stackNames: List<String>?,
+    val authorName: String?,
     val page: Int = 0,
     val size: Int = 30,
 )

--- a/pofo-api/src/main/resources/graphql/project.graphqls
+++ b/pofo-api/src/main/resources/graphql/project.graphqls
@@ -59,6 +59,7 @@ input ProjectSearchRequest {
     title: String
     categories: [ProjectCategory]
     stackNames: [String]
+    authorName: String
     page: Int! = 0
     size: Int! = 30
 }

--- a/pofo-api/src/test/kotlin/org/pofo/api/common/config/KotestConfig.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/common/config/KotestConfig.kt
@@ -3,11 +3,10 @@ package org.pofo.api.common.config
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.IsolationMode
-import io.kotest.extensions.spring.SpringAutowireConstructorExtension
 import io.kotest.extensions.spring.SpringExtension
 
 object KotestConfig : AbstractProjectConfig() {
-    override fun extensions(): List<Extension> = listOf(SpringExtension, SpringAutowireConstructorExtension)
+    override fun extensions(): List<Extension> = listOf(SpringExtension)
 
     override val isolationMode: IsolationMode
         get() = IsolationMode.InstancePerLeaf

--- a/pofo-api/src/test/kotlin/org/pofo/api/common/config/KotestConfig.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/common/config/KotestConfig.kt
@@ -4,14 +4,10 @@ import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.IsolationMode
 import io.kotest.extensions.spring.SpringAutowireConstructorExtension
-import io.kotest.extensions.spring.SpringTestExtension
-import io.kotest.extensions.spring.SpringTestLifecycleMode
+import io.kotest.extensions.spring.SpringExtension
 
-class KotestConfig : AbstractProjectConfig() {
-    override val parallelism = 3
-
-    override fun extensions(): List<Extension> =
-        listOf(SpringTestExtension(SpringTestLifecycleMode.Root), SpringAutowireConstructorExtension)
+object KotestConfig : AbstractProjectConfig() {
+    override fun extensions(): List<Extension> = listOf(SpringExtension, SpringAutowireConstructorExtension)
 
     override val isolationMode: IsolationMode
         get() = IsolationMode.InstancePerLeaf

--- a/pofo-api/src/test/kotlin/org/pofo/api/common/fixture/ProjectFixture.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/common/fixture/ProjectFixture.kt
@@ -4,14 +4,24 @@ import org.pofo.domain.rds.domain.project.Project
 
 class ProjectFixture {
     companion object {
-        fun createProject(): Project =
+        fun createProject(
+            title: String = "Test Project",
+            bio: String = "Test Project Bio",
+            content: String = "Test Project Content",
+            urls: List<String> = listOf(),
+            imageUrls: List<String> = listOf(),
+            keyImageIndex: Int = 0,
+            likes: Int = 0,
+        ): Project =
             Project
                 .builder()
-                .title("Luminia")
-                .Bio("줄거리로 애니를 찾아주고, 애니를 검색하고 리뷰를 달 수 있는 플랫폼입니다.")
-                .content("취업좀 시켜줘라")
-                .urls(listOf("https://github.com/mclub4"))
-                .imageUrls(listOf("https://avatars.githubusercontent.com/u/55117706?v=4"))
+                .title(title)
+                .bio(bio)
+                .content(content)
+                .urls(urls)
+                .imageUrls(imageUrls)
+                .keyImageIndex(keyImageIndex)
+                .likes(likes)
                 .isApproved(false)
                 .build()
     }

--- a/pofo-api/src/test/kotlin/org/pofo/api/common/fixture/UserFixture.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/common/fixture/UserFixture.kt
@@ -5,35 +5,14 @@ import org.pofo.domain.rds.domain.user.UserRole
 
 class UserFixture {
     companion object {
-        private const val TEST_USER_EMAIL = "test@org.com"
-        private const val TEST_USER_PASSWORD = "testPassword"
-        private const val TEST_USERNAME = "testUsername"
-
-        fun createUser(): User =
-            createUser(
-                email = TEST_USER_EMAIL,
-                password = TEST_USER_PASSWORD,
-                username = TEST_USERNAME,
-                role = UserRole.ROLE_USER,
-            )
-
-        fun createUser(role: UserRole): User =
-            createUser(
-                email = TEST_USER_EMAIL,
-                password = TEST_USER_PASSWORD,
-                username = TEST_USERNAME,
-                role = role,
-            )
-
         fun createUser(
-            email: String,
-            password: String,
-            username: String,
-            role: UserRole,
+            email: String = "test@org.com",
+            password: String = "Test Password",
+            username: String = "test Username",
+            role: UserRole = UserRole.ROLE_USER,
         ): User =
             User
                 .builder()
-                .id(1L)
                 .email(email)
                 .password(password)
                 .username(username)

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/like/LikeControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/like/LikeControllerTest.kt
@@ -58,7 +58,7 @@ class LikeControllerTest
                     )
             }
 
-            afterTest {
+            afterEach {
                 likeRepository.deleteAll()
                 projectRepository.deleteAll()
                 userRepository.deleteAll()

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/like/LikeControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/like/LikeControllerTest.kt
@@ -31,7 +31,7 @@ import java.util.concurrent.Executors
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-class LikeControllerTest
+internal class LikeControllerTest
     @Autowired
     constructor(
         private val mockMvc: MockMvc,

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/project/ProjectControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/project/ProjectControllerTest.kt
@@ -1,12 +1,11 @@
 package org.pofo.api.domain.project
 
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Test
+import io.kotest.core.spec.style.StringSpec
 import org.pofo.api.common.fixture.ProjectFixture.Companion.createProject
 import org.pofo.api.common.fixture.UserFixture
 import org.pofo.api.domain.project.dto.ProjectCreateRequest
 import org.pofo.api.domain.project.dto.ProjectResponse
+import org.pofo.api.domain.project.dto.ProjectSearchRequest
 import org.pofo.api.domain.project.dto.ProjectUpdateRequest
 import org.pofo.api.domain.security.jwt.JwtService
 import org.pofo.api.domain.security.jwt.JwtTokenData
@@ -28,320 +27,38 @@ import org.springframework.transaction.annotation.Transactional
 @SpringBootTest
 @Transactional
 @AutoConfigureMockMvc
-@ActiveProfiles(
-    "test",
-)
-internal class ProjectControllerTest
+@ActiveProfiles("test")
+class ProjectControllerTest
     @Autowired
     constructor(
-        mockMvc: MockMvc,
+        private val mockMvc: MockMvc,
         private val userService: UserService,
         private val projectService: ProjectService,
         private val jwtService: JwtService,
-    ) {
-        val user:
-            User =
-            UserFixture
-                .createUser()
-        val client:
-            WebTestClient.Builder =
-            MockMvcWebTestClient
-                .bindTo(
-                    mockMvc,
-                ).baseUrl(
-                    "http://localhost:8080/graphql",
-                )
-        lateinit var savedUser:
-            User
-        lateinit var accessToken:
-            String
+    ) : StringSpec({
+            val user = UserFixture.createUser()
+            val client: WebTestClient.Builder =
+                MockMvcWebTestClient.bindTo(mockMvc).baseUrl("http://localhost:8080/graphql")
+            lateinit var savedUser: User
+            lateinit var accessToken: String
 
-        @BeforeEach
-        fun setUp() {
-            savedUser =
-                userService.createUser(
-                    UserRegisterRequest(
-                        email = user.email,
-                        password = user.password,
-                        username = user.username,
-                    ),
-                )
-            accessToken =
-                jwtService.generateAccessToken(
-                    JwtTokenData(
-                        savedUser,
-                    ),
-                )
-        }
-
-        @Test
-        fun createProjectSuccess() {
-            val project =
-                createProject()
-            val projectCreateRequest =
-                ProjectCreateRequest(
-                    title = project.title,
-                    bio = project.bio,
-                    content = project.content,
-                )
-
-            val graphQlTester =
-                HttpGraphQlTester
-                    .builder(
-                        client,
-                    ).header(
-                        HttpHeaders.AUTHORIZATION,
-                        "Bearer $accessToken",
-                    ).build()
-
-            graphQlTester
-                .documentName(
-                    "createProject",
-                ).variable(
-                    "projectCreateRequest",
-                    projectCreateRequest,
-                ).execute()
-                .path(
-                    "createProject.title",
-                ).entity(
-                    String::class.java,
-                ).isEqualTo(
-                    project.title,
-                ).path(
-                    "createProject.content",
-                ).entity(
-                    String::class.java,
-                ).isEqualTo(
-                    project.content,
-                )
-        }
-
-        @Test
-        fun getProjectById() {
-            // given
-            val savedProject =
-                saveProject(
-                    createProject(),
-                    savedUser.id,
-                )
-
-            val graphQlTester =
-                HttpGraphQlTester
-                    .builder(
-                        client,
-                    ).build()
-
-            // when & then
-            graphQlTester
-                .documentName(
-                    "getProjectById",
-                ).variable(
-                    "projectId",
-                    savedProject.id,
-                ).execute()
-                .path(
-                    "projectById.id",
-                ).entity(
-                    Long::class.java,
-                ).isEqualTo(
-                    savedProject.id,
-                ).path(
-                    "projectById.title",
-                ).entity(
-                    String::class.java,
-                ).isEqualTo(
-                    savedProject.title,
-                )
-        }
-
-        @Test
-        @DisplayName(
-            "페이지 네이션 적은 것 테스트",
-        )
-        fun getAllProjectsByPagination() {
-            // given
-            val savedProjects =
-                mutableListOf<ProjectResponse>()
-            repeat(
-                3,
-            ) {
-                savedProjects
-                    .add(
-                        saveProject(
-                            createProject(),
-                            savedUser.id,
+            beforeEach {
+                savedUser =
+                    userService.createUser(
+                        UserRegisterRequest(
+                            email = user.email,
+                            password = user.password,
+                            username = user.username,
                         ),
                     )
+                accessToken = jwtService.generateAccessToken(JwtTokenData(savedUser))
             }
 
-            val graphQlTester =
-                HttpGraphQlTester
-                    .builder(
-                        client,
-                    ).build()
-
-            // when & then
-            graphQlTester
-                .documentName(
-                    "getAllProjectsByPagination",
-                ).variable(
-                    "cursor",
-                    savedProjects
-                        .last()
-                        .id,
-                ).variable(
-                    "size",
-                    2,
-                ).execute()
-                .path(
-                    "getAllProjectsByPagination.count",
-                ).entity(
-                    Int::class.java,
-                ).isEqualTo(
-                    2,
-                ).path(
-                    "getAllProjectsByPagination.projects[*].title",
-                ).entityList(
-                    String::class.java,
-                ).containsExactly(
-                    savedProjects[1]
-                        .title,
-                    savedProjects[0]
-                        .title,
-                ).path(
-                    "getAllProjectsByPagination.hasNext",
-                ).entity(
-                    Boolean::class.java,
-                ).isEqualTo(
-                    false,
-                )
-        }
-
-        @Test
-        @DisplayName(
-            "2번째 페이지 데이터 검증",
-        )
-        fun getSecondPageProjectsByPaginationTest() {
-            // given
-            val savedProjects =
-                mutableListOf<ProjectResponse>()
-            repeat(
-                20,
-            ) {
-                savedProjects
-                    .add(
-                        saveProject(
-                            createProject(),
-                            savedUser.id,
-                        ),
-                    )
-            }
-
-            val graphQlTester =
-                HttpGraphQlTester
-                    .builder(
-                        client,
-                    ).build()
-
-            val firstPageCursor =
-                savedProjects[
-                    savedProjects.size -
-                        5,
-                ].id
-            val expectedSecondPageProjects =
-                savedProjects
-                    .subList(
-                        10,
-                        15,
-                    ).reversed()
-
-            // when & then
-            graphQlTester
-                .documentName(
-                    "getAllProjectsByPagination",
-                ).variable(
-                    "cursor",
-                    firstPageCursor,
-                ).variable(
-                    "size",
-                    5,
-                ).execute()
-                .path(
-                    "getAllProjectsByPagination.count",
-                ).entity(
-                    Int::class.java,
-                ).isEqualTo(
-                    5,
-                ).path(
-                    "getAllProjectsByPagination.projects[*].title",
-                ).entityList(
-                    String::class.java,
-                ).containsExactly(
-                    *expectedSecondPageProjects
-                        .map {
-                            it.title
-                        }.toTypedArray(),
-                ).path(
-                    "getAllProjectsByPagination.hasNext",
-                ).entity(
-                    Boolean::class.java,
-                ).isEqualTo(
-                    true,
-                )
-        }
-
-        @Test
-        fun updateProject() {
-            // given
-            val savedProject =
-                saveProject(
-                    createProject(),
-                    savedUser.id,
-                )
-            val projectUpdateRequest =
-                ProjectUpdateRequest(
-                    projectId = savedProject.id,
-                    title = "new title",
-                    bio = "new bio",
-                )
-
-            val graphQlTester =
-                HttpGraphQlTester
-                    .builder(
-                        client,
-                    ).header(
-                        HttpHeaders.AUTHORIZATION,
-                        "Bearer $accessToken",
-                    ).build()
-
-            graphQlTester
-                .documentName(
-                    "updateProject",
-                ).variable(
-                    "projectUpdateRequest",
-                    projectUpdateRequest,
-                ).execute()
-                .path(
-                    "updateProject.title",
-                ).entity(
-                    String::class.java,
-                ).isEqualTo(
-                    projectUpdateRequest.title!!,
-                ).path(
-                    "updateProject.bio",
-                ).entity(
-                    String::class.java,
-                ).isEqualTo(
-                    projectUpdateRequest.bio!!,
-                )
-        }
-
-        fun saveProject(
-            project: Project,
-            authorId: Long,
-        ): ProjectResponse =
-            projectService
-                .createProject(
+            fun saveProject(
+                project: Project,
+                authorId: Long,
+            ): ProjectResponse =
+                projectService.createProject(
                     ProjectCreateRequest(
                         title = project.title,
                         bio = project.bio,
@@ -353,4 +70,188 @@ internal class ProjectControllerTest
                     ),
                     authorId = authorId,
                 )
-    }
+
+            "프로젝트 생성" {
+                val project = createProject()
+                val projectCreateRequest =
+                    ProjectCreateRequest(
+                        title = project.title,
+                        bio = project.bio,
+                        content = project.content,
+                    )
+
+                val graphQlTester =
+                    HttpGraphQlTester.builder(client).header(HttpHeaders.AUTHORIZATION, "Bearer $accessToken").build()
+
+                graphQlTester
+                    .documentName("createProject")
+                    .variable("projectCreateRequest", projectCreateRequest)
+                    .execute()
+                    .path("createProject.title")
+                    .entity(String::class.java)
+                    .isEqualTo(project.title)
+                    .path("createProject.content")
+                    .entity(String::class.java)
+                    .isEqualTo(project.content)
+            }
+
+            "프로젝트 검색 - ID를 이용한 단일 검색" {
+                val savedProject = saveProject(createProject(), savedUser.id)
+
+                val graphQlTester = HttpGraphQlTester.builder(client).build()
+
+                graphQlTester
+                    .documentName("getProjectById")
+                    .variable("projectId", savedProject.id)
+                    .execute()
+                    .path("projectById.id")
+                    .entity(Long::class.java)
+                    .isEqualTo(savedProject.id)
+                    .path("projectById.title")
+                    .entity(String::class.java)
+                    .isEqualTo(savedProject.title)
+            }
+
+            "프로젝트 검색 - 페이지네이션" {
+                val savedProjects = mutableListOf<ProjectResponse>()
+                repeat(30) { idx ->
+                    savedProjects.add(saveProject(createProject(title = "Test Project $idx"), savedUser.id))
+                }
+
+                val firstPageRequest =
+                    ProjectSearchRequest(
+                        title = null,
+                        categories = null,
+                        stackNames = null,
+                        authorName = null,
+                        page = 0,
+                        size = 15,
+                    )
+
+                val graphQlTester = HttpGraphQlTester.builder(client).build()
+
+                val expectedFirstPageProjects = savedProjects.subList(15, 30).reversed()
+
+                graphQlTester
+                    .documentName("searchProject")
+                    .variable("projectSearchRequest", firstPageRequest)
+                    .execute()
+                    .path("searchProject.count")
+                    .entity(Int::class.java)
+                    .isEqualTo(15)
+                    .path("searchProject.projects[*].title")
+                    .entityList(String::class.java)
+                    .containsExactly(
+                        *expectedFirstPageProjects.map { project -> project.title }.toTypedArray(),
+                    ).path("searchProject.hasNext")
+                    .entity(Boolean::class.java)
+                    .isEqualTo(true)
+
+                val secondPageRequest =
+                    ProjectSearchRequest(
+                        title = null,
+                        categories = null,
+                        stackNames = null,
+                        authorName = null,
+                        page = 1,
+                        size = 15,
+                    )
+
+                val expectedSecondPageProjects = savedProjects.subList(0, 15).reversed()
+
+                graphQlTester
+                    .documentName("searchProject")
+                    .variable("projectSearchRequest", secondPageRequest)
+                    .execute()
+                    .path("searchProject.count")
+                    .entity(Int::class.java)
+                    .isEqualTo(15)
+                    .path("searchProject.projects[*].title")
+                    .entityList(String::class.java)
+                    .containsExactly(
+                        *expectedSecondPageProjects.map { project -> project.title }.toTypedArray(),
+                    ).path("searchProject.hasNext")
+                    .entity(Boolean::class.java)
+                    .isEqualTo(false)
+            }
+
+            "프로젝트 검색 - 작성자 검색" {
+                val otherSavedUser =
+                    userService.createUser(
+                        UserRegisterRequest(
+                            email = "2_${user.email}",
+                            password = user.password,
+                            username = "2_${user.username}",
+                        ),
+                    )
+                val savedProjects = mutableListOf<ProjectResponse>()
+                repeat(30) { idx ->
+                    savedProjects.add(
+                        saveProject(
+                            createProject(title = "Test Project $idx"),
+                            if (idx % 2 == 0) {
+                                savedUser.id
+                            } else {
+                                otherSavedUser.id
+                            },
+                        ),
+                    )
+                }
+
+                val firstUserRequest =
+                    ProjectSearchRequest(
+                        title = null,
+                        categories = null,
+                        stackNames = null,
+                        authorName = savedUser.username,
+                        page = 0,
+                        size = 30,
+                    )
+
+                val graphQlTester = HttpGraphQlTester.builder(client).build()
+
+                val expectedFirstUserProjects =
+                    savedProjects
+                        .filter { project -> project.authorName == savedUser.username }
+                        .reversed()
+
+                graphQlTester
+                    .documentName("searchProject")
+                    .variable("projectSearchRequest", firstUserRequest)
+                    .execute()
+                    .path("searchProject.count")
+                    .entity(Int::class.java)
+                    .isEqualTo(15)
+                    .path("searchProject.projects[*].title")
+                    .entityList(String::class.java)
+                    .containsExactly(
+                        *expectedFirstUserProjects.map { project -> project.title }.toTypedArray(),
+                    ).path("searchProject.hasNext")
+                    .entity(Boolean::class.java)
+                    .isEqualTo(false)
+            }
+
+            "프로젝트 수정" {
+                val savedProject = saveProject(createProject(), savedUser.id)
+                val projectUpdateRequest =
+                    ProjectUpdateRequest(
+                        projectId = savedProject.id,
+                        title = "new title",
+                        bio = "new bio",
+                    )
+
+                val graphQlTester =
+                    HttpGraphQlTester.builder(client).header(HttpHeaders.AUTHORIZATION, "Bearer $accessToken").build()
+
+                graphQlTester
+                    .documentName("updateProject")
+                    .variable("projectUpdateRequest", projectUpdateRequest)
+                    .execute()
+                    .path("updateProject.title")
+                    .entity(String::class.java)
+                    .isEqualTo(projectUpdateRequest.title!!)
+                    .path("updateProject.bio")
+                    .entity(String::class.java)
+                    .isEqualTo(projectUpdateRequest.bio!!)
+            }
+        })

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/project/ProjectControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/project/ProjectControllerTest.kt
@@ -28,7 +28,7 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-class ProjectControllerTest
+internal class ProjectControllerTest
     @Autowired
     constructor(
         private val mockMvc: MockMvc,
@@ -36,13 +36,14 @@ class ProjectControllerTest
         private val projectService: ProjectService,
         private val jwtService: JwtService,
     ) : StringSpec({
-            val user = UserFixture.createUser()
-            val client: WebTestClient.Builder =
-                MockMvcWebTestClient.bindTo(mockMvc).baseUrl("http://localhost:8080/graphql")
+            lateinit var user: User
+            lateinit var client: WebTestClient.Builder
             lateinit var savedUser: User
             lateinit var accessToken: String
 
             beforeEach {
+                user = UserFixture.createUser()
+                client = MockMvcWebTestClient.bindTo(mockMvc).baseUrl("http://localhost:8080/graphql")
                 savedUser =
                     userService.createUser(
                         UserRegisterRequest(

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/stack/StackControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/stack/StackControllerTest.kt
@@ -42,7 +42,7 @@ internal class StackControllerTest(
 ) : DescribeSpec({
         val objectMapper = jacksonObjectMapper()
 
-        describe("POST /tech-stack - 단일 스택 삽입 시") {
+        describe("단일 스택 삽입") {
             context("이름만 보내면") {
                 it("단일 스택 저장에 성공하고, status 201을 응답한다.") {
                     val stackInsertRequest = StackInsertRequest(name = "Kotlin", imageUrl = null)
@@ -118,7 +118,7 @@ internal class StackControllerTest(
             }
         }
 
-        describe("POST /tech-stack/upload-csv - CSV를 이용한 스택 삽입 시") {
+        describe("CSV를 이용한 스택 삽입") {
             context("form-data에 key를 file해서 stack.csv를 넣으면") {
                 it("CSV 스택 저장에 성공하고, status 201을 응답한다.") {
                     val mockFile = StackFixture.createMockMultipartFile()
@@ -136,7 +136,7 @@ internal class StackControllerTest(
             }
         }
 
-        describe("GET /tech-stack/autocomplete - 스택 자동 완성 검색 시") {
+        describe("스택 자동 완성 검색") {
             context("String으로 된 쿼리를 보내면") {
                 it("status 200과 자동 완성 결과를 응답한다.") {
                     val query = "Rea"

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/stack/StackServiceTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/stack/StackServiceTest.kt
@@ -8,7 +8,7 @@ import org.pofo.api.common.fixture.StackFixture
 import org.pofo.domain.rds.domain.project.Stack
 import org.pofo.domain.rds.domain.project.repository.StackRepository
 
-class StackServiceTest :
+internal class StackServiceTest :
     StringSpec({
         lateinit var stackService: StackService
         lateinit var stackRepository: StackRepository

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/user/UserControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/user/UserControllerTest.kt
@@ -42,14 +42,14 @@ internal class UserControllerTest
             val user: User = UserFixture.createUser()
 
             describe("회원 가입 시") {
-                val requestBody =
-                    UserRegisterRequest(
-                        email = user.email,
-                        password = user.password,
-                        username = user.username,
-                    )
-
                 it("유저 생성에 성공하고, 유저 조회에 성공해야 한다.") {
+                    val requestBody =
+                        UserRegisterRequest(
+                            email = user.email,
+                            password = user.password,
+                            username = user.username,
+                        )
+
                     mockMvc
                         .post(Version.V1 + "/user") {
                             contentType =
@@ -69,6 +69,13 @@ internal class UserControllerTest
 
                 context("중복된 사용자가 있을 때") {
                     it("유저 생성이 실패해야 한다.") {
+                        val requestBody =
+                            UserRegisterRequest(
+                                email = user.email,
+                                password = user.password,
+                                username = user.username,
+                            )
+
                         userService.createUser(
                             UserRegisterRequest(
                                 email = user.email,

--- a/pofo-api/src/test/kotlin/org/pofo/api/domain/user/UserControllerTest.kt
+++ b/pofo-api/src/test/kotlin/org/pofo/api/domain/user/UserControllerTest.kt
@@ -44,7 +44,7 @@ internal class UserControllerTest(
                 username = user.username,
             )
 
-        describe("회원 가입 시") {
+        describe("회원 가입") {
             it("유저 생성에 성공하고, 유저 조회에 성공해야 한다.") {
                 mockMvc
                     .post(Version.V1 + "/user") {
@@ -82,7 +82,7 @@ internal class UserControllerTest(
             }
         }
 
-        describe("로그인 시") {
+        describe("로그인") {
             fun jwtLogin(requestBody: UserLoginRequest): ResultActionsDsl =
                 mockMvc
                     .post(
@@ -151,7 +151,7 @@ internal class UserControllerTest(
             }
         }
 
-        describe("로그아웃 시") {
+        describe("로그아웃") {
             it("엑세스 토큰을 벤하고, 리프레쉬 토큰을 지워야 한다.") {
                 val savedUser = userService.createUser(userRegisterRequest)
                 val accessToken =
@@ -184,7 +184,7 @@ internal class UserControllerTest(
             }
         }
 
-        describe("내 정보 조회 시") {
+        describe("내 정보 조회") {
             it("내 정보가 반환된다.") {
                 val savedUser = userService.createUser(userRegisterRequest)
                 val accessToken =

--- a/pofo-api/src/test/resources/graphql-test/searchProject.graphql
+++ b/pofo-api/src/test/resources/graphql-test/searchProject.graphql
@@ -1,0 +1,10 @@
+query searchProject($projectSearchRequest: ProjectSearchRequest) {
+    searchProject(projectSearchRequest: $projectSearchRequest) {
+        projects {
+            id
+            title
+        }
+        hasNext
+        count
+    }
+}

--- a/pofo-api/src/test/resources/kotest.properties
+++ b/pofo-api/src/test/resources/kotest.properties
@@ -1,2 +1,0 @@
-kotest.framework.classpath.scanning.autoscan.disable=true
-kotest.framework.config.fqn=org.pofo.api.common.config.KotestConfig

--- a/pofo-api/src/test/resources/kotest.properties
+++ b/pofo-api/src/test/resources/kotest.properties
@@ -1,0 +1,2 @@
+kotest.framework.classpath.scanning.autoscan.disable=true
+kotest.framework.config.fqn=org.pofo.api.common.config.KotestConfig

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/Project.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/Project.java
@@ -28,7 +28,7 @@ public class Project {
     private String title;
 
     @Column
-    private String Bio; // 한줄 소개
+    private String bio; // 한줄 소개
 
     @Column
     @Builder.Default
@@ -102,7 +102,7 @@ public class Project {
             this.title = title;
         }
         if (bio != null) {
-            this.Bio = bio;
+            this.bio = bio;
         }
         if (urls != null) {
             this.urls = urls;

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/repository/ProjectCustomRepository.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/repository/ProjectCustomRepository.java
@@ -13,6 +13,7 @@ public interface ProjectCustomRepository {
             String title,
             List<Category> categories,
             List<String> stackNames,
+            String authorName,
             Pageable pageable
     );
 }

--- a/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/repository/ProjectCustomRepositoryImpl.java
+++ b/pofo-domain/src/main/java/org/pofo/domain/rds/domain/project/repository/ProjectCustomRepositoryImpl.java
@@ -45,15 +45,19 @@ public class ProjectCustomRepositoryImpl implements ProjectCustomRepository {
             String title,
             List<Category> categories,
             List<String> stackNames,
+            String authorName,
             Pageable pageable) {
         QProject qProject = QProject.project;
-        QProjectStack qProjectStack = QProjectStack.projectStack;
         BooleanExpression predicate = qProject.isNotNull();
         long offset = pageable.getOffset();
         int pageSize = pageable.getPageSize();
 
         if (title != null) {
             predicate = predicate.and(qProject.title.startsWith(title));
+        }
+
+        if (authorName != null) {
+            predicate = predicate.and(qProject.author.username.eq(authorName));
         }
 
         if (categories != null && !categories.isEmpty()) {
@@ -83,13 +87,6 @@ public class ProjectCustomRepositoryImpl implements ProjectCustomRepository {
         if (hasNext) {
             fetchedProjects.remove(pageSize);
         }
-
-        fetchedProjects.forEach(project -> {
-            List<ProjectStack> stacks = queryFactory.selectFrom(qProjectStack)
-                    .where(qProjectStack.project.id.eq(project.getId()))
-                    .fetch();
-            project.setStacks(stacks);
-        });
 
         return new SliceImpl<>(fetchedProjects, pageable, hasNext);
     }


### PR DESCRIPTION
## Overview

유저 이름으로도 프로젝트를 검색할 수 있도록 변경했습니다.

### Related Issue
Issue Number : resolves #93 

## Task Details

- authorName이 기존에 email이였던걸 username으로 변경
- searchProject에 authorName 추가 및 SQL 문 추가
- ProjectTest kotest StringSpec으로 변경
- 테스트 이름 획일화
- 테스트 동시성 문제 해결

## Review Requirements

- ProjectTest를 StringSpec으로 변경했습니다. 기존에 사용하던 DescribeSpec와 다른 간결한 테스트를 한 이유는 빠르게 작성하려고도 했고, 여러가지 테스트를 해보려고 입니다.
- 테스트 이름에 대한 수정이 있었습니다. ~ 시 라는 단어가 반복되는건 의미가 없다고 생각해서 뺐습니다.
![image](https://github.com/user-attachments/assets/4bfde5de-1109-4b3f-b4bf-96f813f50eb3)

- 테스트의 속도를 올리기 위해 동시성 레벨을 올렸다가 엄청 혼났습니다.
- 각 테스트의 멱등성에 대해서도 생각해볼 수 있었습니다. 예를들어 Stack 단위 테스트는 다른 테스트와의 접점이 없어 아무런 문제 없이 작동했습니다.
- 대부분 유저의 이메일 중복에서 발생했습니다. 다른 테스트에서 이미 롤백이 되지 않았는데 유저를 생성한다던지.. (왜 컬럼을 FixtureMonkey나 KotlinFixture같은 라이브러리로 유니크하게 구성하거나 데이터베이스 자체를 컨테이너화 하여 분리하는지 이해했습니다..)
![image](https://github.com/user-attachments/assets/cd9003ec-2111-4a84-84d3-10bb650043c6)

- 저번에 얘기했던 빌더 문제가 여전히 진행중입니다..
- 빌더는 아시지만 어떤 컬럼을 빼놓더라도 그냥 null로 채우고 Project를 생성해버립니다.
- Kotlin의 named parameter를 사용하면 어떤게 빠졌는지, 기본값 등등 설정할 수 있는데.. 개선할 수 있는 방법이 없을지 물어보고 싶습니다.
![image](https://github.com/user-attachments/assets/ece393a3-2405-4346-8320-54c36e398a7e)
