### PR TITLE
feat: 로컬 환경에서 InMemoryTokenRepository를 이용한 Redis 의존성 제거

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,15 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     container: node:20-bookworm-slim
 
-    services:
-      redis:
-        image: redis
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     permissions:
       contents: read
 
@@ -32,6 +23,3 @@ jobs:
         uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
       - name: Build with Gradle Wrapper
         run: ./gradlew build
-        env:
-          REDIS_HOST: redis
-          REDIS_PORT: 6379

--- a/src/main/kotlin/org/pofo/api/domain/security/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/org/pofo/api/domain/security/jwt/JwtAuthenticationFilter.kt
@@ -5,17 +5,20 @@ import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.pofo.api.domain.security.PrincipalDetails
+import org.pofo.api.domain.security.token.BannedAccessToken
+import org.pofo.api.domain.security.token.TokenRepository
 import org.springframework.http.HttpHeaders
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
-private val logger = KotlinLogging.logger {}
+private val log = KotlinLogging.logger {}
 
 @Component
 class JwtAuthenticationFilter(
     private val jwtService: JwtService,
+    private val bannedAccessTokenTokenRepository: TokenRepository<BannedAccessToken>,
 ) : OncePerRequestFilter() {
     override fun doFilterInternal(
         request: HttpServletRequest,
@@ -23,10 +26,18 @@ class JwtAuthenticationFilter(
         filterChain: FilterChain,
     ) {
         val accessTokenInHeader = request.getHeader(HttpHeaders.AUTHORIZATION)
+
         if (accessTokenInHeader != null && accessTokenInHeader.startsWith("Bearer ")) {
             val accessToken = accessTokenInHeader.substring(7)
             val jwtTokenData = jwtService.extractTokenData(accessToken)
-            logger.debug { "Access token detected: $accessToken" }
+            log.debug { "Access token detected: $accessToken" }
+
+            val bannedAccessToken = bannedAccessTokenTokenRepository.findByUserIdOrNull(jwtTokenData.userId)
+
+            if (bannedAccessToken != null) {
+                log.debug { "Banned access token detected: $bannedAccessToken" }
+                return filterChain.doFilter(request, response)
+            }
 
             val principal = PrincipalDetails(jwtTokenData)
             val token = UsernamePasswordAuthenticationToken(principal, "", principal.authorities)

--- a/src/main/kotlin/org/pofo/api/domain/security/oauth2/OAuth2AuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/org/pofo/api/domain/security/oauth2/OAuth2AuthenticationSuccessHandler.kt
@@ -6,7 +6,7 @@ import org.pofo.api.common.util.CookieUtil
 import org.pofo.api.domain.security.PrincipalDetails
 import org.pofo.api.domain.security.jwt.JwtService
 import org.pofo.api.domain.security.token.RefreshToken
-import org.pofo.api.domain.security.token.RefreshTokenRepository
+import org.pofo.api.domain.security.token.TokenRepository
 import org.pofo.api.domain.user.UserController
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.env.Environment
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component
 @Component
 class OAuth2AuthenticationSuccessHandler(
     private val jwtService: JwtService,
-    private val refreshTokenRepository: RefreshTokenRepository,
+    private val refreshTokenRepository: TokenRepository<RefreshToken>,
     private val cookieUtil: CookieUtil,
     private val environment: Environment,
 ) : SimpleUrlAuthenticationSuccessHandler() {

--- a/src/main/kotlin/org/pofo/api/domain/security/token/BannedAccessToken.kt
+++ b/src/main/kotlin/org/pofo/api/domain/security/token/BannedAccessToken.kt
@@ -1,14 +1,13 @@
 package org.pofo.api.domain.security.token
 
-import org.springframework.data.annotation.Id
-import org.springframework.data.redis.core.RedisHash
-import org.springframework.data.redis.core.TimeToLive
-
-@RedisHash("banned_access_token")
 class BannedAccessToken(
-    @Id
-    val userId: Long,
-    val value: String,
-    @TimeToLive
-    val expiration: Long,
-)
+    userId: Long,
+    value: String,
+    expiration: Long,
+) : Token(userId, value, expiration) {
+    companion object {
+        const val BANNED_ACCESS_TOKEN_KEY = "banned_access_token"
+    }
+
+    override fun getKey(): String = "${BANNED_ACCESS_TOKEN_KEY}:$userId"
+}

--- a/src/main/kotlin/org/pofo/api/domain/security/token/BannedAccessTokenRepository.kt
+++ b/src/main/kotlin/org/pofo/api/domain/security/token/BannedAccessTokenRepository.kt
@@ -1,5 +1,0 @@
-package org.pofo.api.domain.security.token
-
-import org.springframework.data.repository.CrudRepository
-
-interface BannedAccessTokenRepository : CrudRepository<BannedAccessToken, Long>

--- a/src/main/kotlin/org/pofo/api/domain/security/token/InMemoryTokenRepository.kt
+++ b/src/main/kotlin/org/pofo/api/domain/security/token/InMemoryTokenRepository.kt
@@ -1,0 +1,49 @@
+package org.pofo.api.domain.security.token
+
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.concurrent.fixedRateTimer
+
+class InMemoryTokenRepository<T : Token> : TokenRepository<T> {
+    private val store = ConcurrentHashMap<Long, String>()
+    private val ttlMap = ConcurrentHashMap<Long, Long>()
+
+    init {
+        fixedRateTimer("cleanUp", initialDelay = 0, period = 5 * 60 * 1000) {
+            cleanUpExpiredTokens()
+        }
+    }
+
+    override fun save(token: T) {
+        store[token.userId] = token.value
+        ttlMap[token.userId] =
+            Instant.now().toEpochMilli() + token.expiration
+    }
+
+    override fun findByUserIdOrNull(userId: Long): String? {
+        val ttl = ttlMap[userId]
+        if (ttl != null && ttl < Instant.now().toEpochMilli()) {
+            store.remove(userId)
+            ttlMap.remove(userId)
+            return null
+        }
+        return store[userId]
+    }
+
+    override fun deleteByUserId(userId: Long) {
+        store.remove(userId)
+        ttlMap.remove(userId)
+    }
+
+    private fun cleanUpExpiredTokens() {
+        val now = Instant.now().toEpochMilli()
+        ttlMap.entries.removeIf { (userId, expirationTime) ->
+            if (expirationTime < now) {
+                store.remove(userId)
+                true
+            } else {
+                false
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/pofo/api/domain/security/token/RedisTokenRepository.kt
+++ b/src/main/kotlin/org/pofo/api/domain/security/token/RedisTokenRepository.kt
@@ -1,0 +1,27 @@
+package org.pofo.api.domain.security.token
+
+import org.springframework.data.redis.core.RedisTemplate
+
+class RedisTokenRepository<T : Token>(
+    private val redisTemplate: RedisTemplate<String, String>,
+) : TokenRepository<T> {
+    companion object {
+        const val BANNED_ACCESS_TOKEN_KEY = "banned_access_token"
+    }
+
+    override fun save(token: T) {
+        val fieldKey = "$BANNED_ACCESS_TOKEN_KEY:${token.userId}"
+        redisTemplate.opsForValue().set(
+            fieldKey,
+            token.value,
+            token.expiration / 1000,
+        )
+    }
+
+    override fun findByUserIdOrNull(userId: Long): String? = redisTemplate.opsForValue().get(userId)
+
+    override fun deleteByUserId(userId: Long) {
+        val fieldKey = "$BANNED_ACCESS_TOKEN_KEY:$userId"
+        redisTemplate.delete(fieldKey)
+    }
+}

--- a/src/main/kotlin/org/pofo/api/domain/security/token/RefreshToken.kt
+++ b/src/main/kotlin/org/pofo/api/domain/security/token/RefreshToken.kt
@@ -1,14 +1,13 @@
 package org.pofo.api.domain.security.token
 
-import org.springframework.data.annotation.Id
-import org.springframework.data.redis.core.RedisHash
-import org.springframework.data.redis.core.TimeToLive
-
-@RedisHash("refresh_token")
 class RefreshToken(
-    @Id
-    val userId: Long,
-    val value: String,
-    @TimeToLive
-    val expiration: Long,
-)
+    userId: Long,
+    value: String,
+    expiration: Long,
+) : Token(userId, value, expiration) {
+    companion object {
+        const val REFRESH_TOKEN_KEY = "refresh_token"
+    }
+
+    override fun getKey(): String = "${REFRESH_TOKEN_KEY}:$userId"
+}

--- a/src/main/kotlin/org/pofo/api/domain/security/token/RefreshTokenRepository.kt
+++ b/src/main/kotlin/org/pofo/api/domain/security/token/RefreshTokenRepository.kt
@@ -1,5 +1,0 @@
-package org.pofo.api.domain.security.token
-
-import org.springframework.data.repository.CrudRepository
-
-interface RefreshTokenRepository : CrudRepository<RefreshToken, Long>

--- a/src/main/kotlin/org/pofo/api/domain/security/token/Token.kt
+++ b/src/main/kotlin/org/pofo/api/domain/security/token/Token.kt
@@ -1,0 +1,9 @@
+package org.pofo.api.domain.security.token
+
+abstract class Token(
+    val userId: Long,
+    val value: String,
+    val expiration: Long,
+) {
+    abstract fun getKey(): String
+}

--- a/src/main/kotlin/org/pofo/api/domain/security/token/TokenRepository.kt
+++ b/src/main/kotlin/org/pofo/api/domain/security/token/TokenRepository.kt
@@ -1,0 +1,9 @@
+package org.pofo.api.domain.security.token
+
+interface TokenRepository<T : Token> {
+    fun save(token: T)
+
+    fun findByUserIdOrNull(userId: Long): String?
+
+    fun deleteByUserId(userId: Long)
+}

--- a/src/main/kotlin/org/pofo/api/domain/security/token/TokenRepositoryConfig.kt
+++ b/src/main/kotlin/org/pofo/api/domain/security/token/TokenRepositoryConfig.kt
@@ -1,0 +1,28 @@
+package org.pofo.api.domain.security.token
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.data.redis.core.RedisTemplate
+
+@Configuration
+class TokenRepositoryConfig {
+    @Bean
+    @Profile("local")
+    fun inMemoryBannedAccessTokenRepository(): TokenRepository<BannedAccessToken> = InMemoryTokenRepository()
+
+    @Bean
+    @Profile("!local")
+    fun redisBannedAccessTokenRepository(
+        redisTemplate: RedisTemplate<String, String>,
+    ): TokenRepository<BannedAccessToken> = RedisTokenRepository(redisTemplate)
+
+    @Bean
+    @Profile("local")
+    fun inMemoryRefreshTokenRepository(): TokenRepository<RefreshToken> = InMemoryTokenRepository()
+
+    @Bean
+    @Profile("!local")
+    fun redisRefreshTokenRepository(redisTemplate: RedisTemplate<String, String>): TokenRepository<RefreshToken> =
+        RedisTokenRepository(redisTemplate)
+}

--- a/src/test/kotlin/org/pofo/api/domain/user/UserControllerTest.kt
+++ b/src/test/kotlin/org/pofo/api/domain/user/UserControllerTest.kt
@@ -9,7 +9,8 @@ import org.pofo.api.common.fixture.UserFixture
 import org.pofo.api.common.util.Version
 import org.pofo.api.domain.security.jwt.JwtService
 import org.pofo.api.domain.security.jwt.JwtTokenData
-import org.pofo.api.domain.security.token.BannedAccessTokenRepository
+import org.pofo.api.domain.security.token.BannedAccessToken
+import org.pofo.api.domain.security.token.TokenRepository
 import org.pofo.api.domain.user.dto.UserLoginRequest
 import org.pofo.api.domain.user.dto.UserRegisterRequest
 import org.springframework.beans.factory.annotation.Autowired
@@ -31,7 +32,7 @@ import org.springframework.transaction.annotation.Transactional
 internal class UserControllerTest(
     @Autowired private val mockMvc: MockMvc,
     @Autowired private val userService: UserService,
-    @Autowired private val bannedAccessTokenRepository: BannedAccessTokenRepository,
+    @Autowired private val bannedAccessTokenRepository: TokenRepository<BannedAccessToken>,
     @Autowired private val jwtService: JwtService,
 ) : DescribeSpec({
         val objectMapper = jacksonObjectMapper()
@@ -176,10 +177,10 @@ internal class UserControllerTest(
                         }
                     }
 
-                val bannedAccessTokenOptional =
-                    bannedAccessTokenRepository.findById(savedUser.id)
-                bannedAccessTokenOptional.isPresent shouldBe true
-                bannedAccessTokenOptional.get().value shouldBe accessToken
+                val bannedAccessToken =
+                    bannedAccessTokenRepository.findByUserIdOrNull(savedUser.id)
+                bannedAccessToken.shouldNotBeNull()
+                bannedAccessToken shouldBe accessToken
             }
         }
 


### PR DESCRIPTION
## Overview

로컬 환경에서 준비 없이 실행이 가능하도록 InMemoryTokenRepository를 구현했습니다.

### Related Issue
Issue Number : resolves #95 

## Task Details

- ConcurrentHashMap을 사용해서 Redis와 똑같은 TokenRepository를 구현했습니다.
  - TTL 또한 다른 Map에 저장해서 사용합니다.
- local 환경인 경우에 InMemoryTokenRepository를 사용하고, 이외에는 RedisTokenRepository를 사용합니다.
- 리포지토리가 상속으로 구현되어있어, 기존 코드에서는 Redis의 존재 유무를 몰라도 됩니다.
```kotlin
private val refreshTokenRepository: TokenRepository<RefreshToken>,
private val bannedAccessTokenRepository: TokenRepository<BannedAccessToken>,
```
- 테스트도 이제 데이터베이스의 실행이 필요 없습니다.

## Review Requirements

로컬 환경에선 최대한 가볍고 빠르게 실행해서 개발하는 것이 좋다고 생각했습니다.
개발 서버 환경과 최대한 같게 구현해 보았는데 의견 주세요!